### PR TITLE
Shorten title by removing deprecated term

### DIFF
--- a/entries/SWC-106.md
+++ b/entries/SWC-106.md
@@ -1,5 +1,5 @@
 # Title 
-Unprotected SELFDESTRUCT/SUICIDE Instruction
+Unprotected SELFDESTRUCT Instruction
 
 ## Relationships
 [CWE-284: Improper Access Control](https://cwe.mitre.org/data/definitions/284.html)
@@ -10,7 +10,7 @@ Due to missing or insufficient access controls, malicious parties can self-destr
 
 ## Remediation
 
-Consider removing the self-destruct functionality unless it is absolutely required. If there is valid use-case, it is recommended to implement multisig scheme so that multiple parties must approve the self-destruct action.
+Consider removing the self-destruct functionality unless it is absolutely required. If there is a valid use-case, it is recommended to implement a multisig scheme so that multiple parties must approve the self-destruct action.
 
 ## References 
 - [Parity "I accidentally killed it" bug](https://www.parity.io/a-postmortem-on-the-parity-multi-sig-library-self-destruct/)


### PR DESCRIPTION
There is no suicide instruction any more (only selfdestruct in the Yellow Paper)