### PR TITLE
Title changes / CWE links

### DIFF
--- a/entries/SWC-110.md
+++ b/entries/SWC-110.md
@@ -3,7 +3,7 @@ Assert Violation
 
 ## Relationships
 
-[CWE-617: Reachable Assertion](https://cwe.mitre.org/data/definitions/617.html)
+[CWE-670: Always-Incorrect Control Flow Implementation](https://cwe.mitre.org/data/definitions/670.html)
 
 ## Description 
 

--- a/entries/SWC-120.md
+++ b/entries/SWC-120.md
@@ -1,5 +1,5 @@
 # Title 
-Weak Sources of Randomness  
+Weak Sources of Randomness from Chain Attributes
 
 ## Relationships
 [CWE-330: Use of Insufficiently Random Values](https://cwe.mitre.org/data/definitions/330.html)

--- a/entries/SWC-122.md
+++ b/entries/SWC-122.md
@@ -1,16 +1,16 @@
 # Title 
-Improper Signature Verification 
+Missing Proper Signature Verification 
 
 ## Relationships
-[CWE-347: Improper Verification of Cryptographic Signature](https://cwe.mitre.org/data/definitions/347.html)
+[CWE-345: Insufficient Verification of Data Authenticity](https://cwe.mitre.org/data/definitions/345.html)
 
 ## Description 
-Many smart contract systems allow users to sign off-chain messages instead of directly requesting users to do an on-chain transaction. These systems usually assume that the message will be signed by the same address that owns the assets. However, one can hold assets directly in the regular account (controlled by a private key) or in a smart contract that acts as a wallet (e.g. a multisig contract). The current design of many smart contracts prevent contract based accounts from interacting with them, since contracts do not possess private keys and therefore can not directly sign messages. In order to solve the problem implementations that assume the validity of a signed message based on other methods that do not have that barrier. An example of such a method is to use `msg.sender`  and assume if the message originated from the address then it is valid. This can lead to vulnerabilties especially in scenarios where proxies can be used to relay transactions.
+Many smart contract systems allow users to sign off-chain messages instead of directly requesting users to do an on-chain transaction. These systems usually assume that the message will be signed by the same address that owns the assets. However, one can hold assets directly in the regular account (controlled by a private key) or in a smart contract that acts as a wallet (e.g. a multisig contract). The current design of many smart contracts prevent contract based accounts from interacting with them, since contracts do not possess private keys and therefore can not directly sign messages. In order to solve the problem implementations that assume the validity of a signed message based on other methods that do not have that barrier. An example of such a method is to use `msg.sender` and assume if the message originated from the address then it is valid. This can lead to vulnerabilties especially in scenarios where proxies can be used to relay transactions.
 
 
 ## Remediation
 
-It is not recommneded to use alternate verifcation schemes that do require proper signature verification through `ecrecover()`. 
+It is not recommended to use alternate verifcation schemes that do require proper signature verification through `ecrecover()`. 
 
 
 ## References

--- a/entries/SWC-122.md
+++ b/entries/SWC-122.md
@@ -1,5 +1,5 @@
 # Title 
-Missing Proper Signature Verification 
+Lack of Proper Signature Verification 
 
 ## Relationships
 [CWE-345: Insufficient Verification of Data Authenticity](https://cwe.mitre.org/data/definitions/345.html)


### PR DESCRIPTION
- SWC-110: was linking to a CWE variant. Changed to its closest parent. 
- SWC-120: "Weak Sources of Randomness" is fairly broad, the title narrows it down to Ethereum chain attributes. 
- SWC-122: Link to "CWE-345: Insufficient Verification of Data Authenticity" class type as this fits better and change title 