### PR TITLE
add SWC-registry utils tool

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
+    "command-exists": "^1.2.8",
     "chalk": "^2.4.2",
     "js-yaml": "^3.12.1",
     "jsonlint": "^1.6.3",

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,102 @@
+const commandExistsSync = require('command-exists').sync;
+const fs = require('fs');
+const spawnSync = require('child_process').spawnSync;
+const command = process.argv[2];
+
+const checkGeth = () => {
+  if(commandExistsSync('geth')) {
+    console.log('geth installed');
+  } else {
+    console.log('You should have geth installed and running for using this tool.');
+    console.log('exit');
+    process.exit(1);
+  }
+}
+
+const checkMyth = () => {
+  if(commandExistsSync('myth')) {
+    console.log('myth installed');
+  } else {
+    console.log('You should have myth installed to using this tool.');
+    process.exit(1);
+  }
+}
+
+const printFinalOutput = (fileName, bin, binSha3, binDisasm, binRuntime, binRuntimeSha3, binRuntimeDisasm) => {
+  console.log('\nContract:' + fileName);
+  console.log('Creation Bytecode:' + bin);
+  console.log('Keccak256 Hash:' + binSha3);
+  console.log(binDisasm);
+  console.log('\nRuntime Bytecode:' + binRuntime);
+  console.log('Keccak256 Hash:' + binRuntimeSha3);
+  console.log(binRuntimeDisasm);
+}
+
+const getSha3 = (bytecode) => {
+  var spawn = spawnSync('geth',['--exec "web3.sha3(' + bytecode + ')" attach'],{shell:true});
+	var errorText = spawn.stderr.toString().trim();
+
+	if (errorText) {
+	  console.log('Fatal error from `geth attach`.');
+    console.log('You should check if geth is running and the correctness of bin/bin-runtime in compile artifact');
+    process.exit(1);
+	}
+	else {
+	  return spawn.stdout.toString().trim();
+	}
+}
+
+const getDisasm = (bytecode) => {
+  var spawn = spawnSync('myth',['-d', '-c', bytecode]);
+  var errorText = spawn.stderr.toString().trim();
+
+	if (errorText) {
+	  console.log('Fatal error from `myth -d -c [bytecode]`.');
+    console.log(errorText);
+    process.exit(1);
+	}
+	else {
+	  return spawn.stdout.toString().trim();
+	}
+}
+
+const checkByteCode = () => {
+  if(!command) {
+    console.log('You should enter a path to a compile artifact')
+    process.exit(1);
+  }
+  let artefact = JSON.parse(fs.readFileSync(command, 'utf8'));
+  let fileName = Object.keys(artefact.contracts)[0];
+  if(fileName) {
+    let bin = artefact.contracts[fileName].bin;
+    let binRuntime = artefact.contracts[fileName]['bin-runtime'];
+    if(bin && binRuntime) {
+      let binSha3 = getSha3("'" + bin + "'");
+      let binRuntimeSha3 = getSha3("'" + binRuntime + "'");
+      if(!binSha3 || !binRuntimeSha3) {
+        console.log('You should check if geth is running and the correctness of bin/bin-runtime in compile artifact');
+        process.exit(1);
+      }
+      let binDisasm = getDisasm(bin);
+      let binRuntimeDisasm = getDisasm(binRuntime);
+      printFinalOutput(fileName, bin, binSha3, binDisasm, binRuntime, binRuntimeSha3, binRuntimeDisasm);
+
+    }
+    else {
+      console.log('bin or bin-runtime missing in compile artifact.');
+      process.exit(1);
+    }
+
+  }
+  else {
+    console.log('You should insert a valid compile artefact');
+    process.exit(1);
+  }
+}
+
+const generateOutput = () => {
+  checkGeth();
+  checkMyth();
+  checkByteCode();
+}
+generateOutput();

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -25,7 +25,7 @@ const printFinalOutput = (fileName, bin, binSha3, binDisasm, binRuntime, binRunt
 }
 
 const getSha3 = (bytecode) => {
-  return web3.utils.sha3(bytecode);
+  return web3.utils.sha3('0x' + bytecode);
 }
 
 const getDisasm = (bytecode) => {
@@ -44,35 +44,39 @@ const getDisasm = (bytecode) => {
 
 const checkByteCode = () => {
   if(!command) {
-    console.log('You should enter a path to a compile artifact')
+    console.log('You should enter a path to a compile artifact.')
     process.exit(1);
   }
   let artefact = JSON.parse(fs.readFileSync(command, 'utf8'));
-  let fileName = Object.keys(artefact.contracts)[0];
-  if(fileName) {
-    let bin = artefact.contracts[fileName].bin;
-    let binRuntime = artefact.contracts[fileName]['bin-runtime'];
-    if(bin && binRuntime) {
-      let binSha3 = getSha3(bin);
-      let binRuntimeSha3 = getSha3(binRuntime);
-      if(!binSha3 || !binRuntimeSha3) {
-        console.log('You should check if geth is running and the correctness of bin/bin-runtime in compile artifact');
-        process.exit(1);
+  let numberBytecodesPair = Object.keys(artefact.contracts);
+  if(numberBytecodesPair.length == 0) {
+    console.log('There are no bin and bin-runtime into compile artifact.');
+    process.exit(1);
+  }
+  for(let i=0;i<numberBytecodesPair.length;i++) {
+    let fileName = Object.keys(artefact.contracts)[i];
+    if(fileName) {
+      let bin = artefact.contracts[fileName].bin;
+      let binRuntime = artefact.contracts[fileName]['bin-runtime'];
+      if(bin && binRuntime) {
+        let binSha3 = getSha3(bin);
+        let binRuntimeSha3 = getSha3(binRuntime);
+        if(!binSha3 || !binRuntimeSha3) {
+          console.log('You should check the correctness of bin/bin-runtime into compile artifact.');
+          process.exit(1);
+        }
+        let binDisasm = getDisasm(bin);
+        let binRuntimeDisasm = getDisasm(binRuntime);
+        printFinalOutput(fileName, bin, binSha3, binDisasm, binRuntime, binRuntimeSha3, binRuntimeDisasm);
       }
-      let binDisasm = getDisasm(bin);
-      let binRuntimeDisasm = getDisasm(binRuntime);
-      printFinalOutput(fileName, bin, binSha3, binDisasm, binRuntime, binRuntimeSha3, binRuntimeDisasm);
-
+      else {
+        console.log('\nbin and bin-runtime missing in ' + fileName);
+      }
     }
     else {
-      console.log('bin or bin-runtime missing in compile artifact.');
+      console.log('You should insert a valid compile artefact.');
       process.exit(1);
     }
-
-  }
-  else {
-    console.log('You should insert a valid compile artefact');
-    process.exit(1);
   }
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,17 +1,9 @@
 const commandExistsSync = require('command-exists').sync;
 const fs = require('fs');
 const spawnSync = require('child_process').spawnSync;
+const web3 = require('Web3');
 const command = process.argv[2];
 
-const checkGeth = () => {
-  if(commandExistsSync('geth')) {
-    console.log('geth installed');
-  } else {
-    console.log('You should have geth installed and running for using this tool.');
-    console.log('exit');
-    process.exit(1);
-  }
-}
 
 const checkMyth = () => {
   if(commandExistsSync('myth')) {
@@ -33,17 +25,7 @@ const printFinalOutput = (fileName, bin, binSha3, binDisasm, binRuntime, binRunt
 }
 
 const getSha3 = (bytecode) => {
-  var spawn = spawnSync('geth',['--exec "web3.sha3(' + bytecode + ')" attach'],{shell:true});
-	var errorText = spawn.stderr.toString().trim();
-
-	if (errorText) {
-	  console.log('Fatal error from `geth attach`.');
-    console.log('You should check if geth is running and the correctness of bin/bin-runtime in compile artifact');
-    process.exit(1);
-	}
-	else {
-	  return spawn.stdout.toString().trim();
-	}
+  return web3.utils.sha3(bytecode);
 }
 
 const getDisasm = (bytecode) => {
@@ -71,8 +53,8 @@ const checkByteCode = () => {
     let bin = artefact.contracts[fileName].bin;
     let binRuntime = artefact.contracts[fileName]['bin-runtime'];
     if(bin && binRuntime) {
-      let binSha3 = getSha3("'" + bin + "'");
-      let binRuntimeSha3 = getSha3("'" + binRuntime + "'");
+      let binSha3 = getSha3(bin);
+      let binRuntimeSha3 = getSha3(binRuntime);
       if(!binSha3 || !binRuntimeSha3) {
         console.log('You should check if geth is running and the correctness of bin/bin-runtime in compile artifact');
         process.exit(1);
@@ -95,7 +77,6 @@ const checkByteCode = () => {
 }
 
 const generateOutput = () => {
-  checkGeth();
   checkMyth();
   checkByteCode();
 }


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->
- The util tool uses `myth` instead of `evm` to disasm the bytecode.
- Right now it uses `geth` only for `sha3()` the bytecode, it could be substitute with Web3 js library.
##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: #170 
