### PR TITLE
Improve Github checkers

### DIFF
--- a/scripts/dir_structure.js
+++ b/scripts/dir_structure.js
@@ -17,16 +17,29 @@ let hasError = false;
 const files = walkSync('../test_cases');
 
 files.map(file => {
-    const splitedPath = file.split('/');
-
-    const [filepath, folder, ...rest] = splitedPath.reverse();
-    const [filename, ...restels] = filepath.split('.');
+    if (file.endsWith(".sol")) {
+        const splitedPath = file.split('/');
     
-    if (folder !== filename) {
-        hasError = true;
-        console.log(`Path is wrong: ${file}`);
+        const [filepath, folder, ...rest] = splitedPath.reverse();
+        const [filename, ...restels] = filepath.split('.');
+        
+        if (folder !== filename) {
+            hasError = true;
+            console.log(`Path is wrong: ${file}`);
+        }
+
+        if (!fs.existsSync(file.replace(".sol", ".yaml"))) {
+            hasError = true;
+            console.log(`Test case config is missing for: ${file}`);
+        }
+
+        if (!fs.existsSync(file.replace(".sol", ".json"))) {
+            hasError = true;
+            console.log(`Solc output config is missing for: ${file}`);
+        }
     }
 });
+
 
 if (hasError) {
     process.exit(1);

--- a/scripts/dir_structure.js
+++ b/scripts/dir_structure.js
@@ -1,10 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 
-const walkSync = (dir, filelist=[]) => {
+const walkSync = (dir, filelist = []) => {
     fs.readdirSync(dir).forEach((file) => {
-        if(fs.statSync(path.join(dir, file)).isDirectory()) {
-            filelist =  walkSync(path.join(dir, file), filelist)
+        if (fs.statSync(path.join(dir, file)).isDirectory()) {
+            filelist = walkSync(path.join(dir, file), filelist)
         } else {
             filelist = filelist.concat(path.join(dir, file));
         }
@@ -19,10 +19,10 @@ const files = walkSync('../test_cases');
 files.map(file => {
     if (file.endsWith(".sol")) {
         const splitedPath = file.split('/');
-    
+
         const [filepath, folder, ...rest] = splitedPath.reverse();
         const [filename, ...restels] = filepath.split('.');
-        
+
         if (folder !== filename) {
             hasError = true;
             console.log(`Path is wrong: ${file}`);
@@ -30,12 +30,12 @@ files.map(file => {
 
         if (!fs.existsSync(file.replace(".sol", ".yaml"))) {
             hasError = true;
-            console.log(`Test case config is missing for: ${file}`);
+            console.log(`Yaml file is missing for: ${file}`);
         }
 
         if (!fs.existsSync(file.replace(".sol", ".json"))) {
             hasError = true;
-            console.log(`Solc output config is missing for: ${file}`);
+            console.log(`JSON file is missing for: ${file}`);
         }
     }
 });

--- a/test_cases/solidity/outdated_compiler_version/version_0_4_13/version_0_4_13.json
+++ b/test_cases/solidity/outdated_compiler_version/version_0_4_13/version_0_4_13.json
@@ -1,0 +1,110 @@
+{
+    "contracts": {
+        "version_0_4_13.sol:OutdatedCompilerVersion": {
+            "bin": "606060405260016000553415601357600080fd5b5b6095806100226000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630c55699c14603d575b600080fd5b3415604757600080fd5b604d6063565b6040518082815260200191505060405180910390f35b600054815600a165627a7a723058203a85800af5fe5ee02b4c3b99c92da06b7a9600ed790147de8196e7b7a47772690029",
+            "bin-runtime": "60606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630c55699c14603d575b600080fd5b3415604757600080fd5b604d6063565b6040518082815260200191505060405180910390f35b600054815600a165627a7a723058203a85800af5fe5ee02b4c3b99c92da06b7a9600ed790147de8196e7b7a47772690029",
+            "srcmap": "25:59:0:-;;;80:1;64:17;;25:59;;;;;;;;;;;;;;;",
+            "srcmap-runtime": "25:59:0:-;;;;;;;;;;;;;;;;;;;64:17;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o"
+        }
+    },
+    "sourceList": [
+        "version_0_4_13.sol"
+    ],
+    "sources": {
+        "version_0_4_13.sol": {
+            "AST": {
+                "attributes": {
+                    "absolutePath": "version_0_4_13.sol",
+                    "exportedSymbols": {
+                        "OutdatedCompilerVersion": [
+                            5
+                        ]
+                    }
+                },
+                "children": [
+                    {
+                        "attributes": {
+                            "literals": [
+                                "solidity",
+                                "0.4",
+                                ".13"
+                            ]
+                        },
+                        "id": 1,
+                        "name": "PragmaDirective",
+                        "src": "0:23:0"
+                    },
+                    {
+                        "attributes": {
+                            "baseContracts": [
+                                null
+                            ],
+                            "contractDependencies": [
+                                null
+                            ],
+                            "contractKind": "contract",
+                            "documentation": null,
+                            "fullyImplemented": true,
+                            "linearizedBaseContracts": [
+                                5
+                            ],
+                            "name": "OutdatedCompilerVersion",
+                            "scope": 6
+                        },
+                        "children": [
+                            {
+                                "attributes": {
+                                    "constant": false,
+                                    "name": "x",
+                                    "scope": 5,
+                                    "stateVariable": true,
+                                    "storageLocation": "default",
+                                    "type": "uint256",
+                                    "visibility": "public"
+                                },
+                                "children": [
+                                    {
+                                        "attributes": {
+                                            "name": "uint",
+                                            "type": "uint256"
+                                        },
+                                        "id": 2,
+                                        "name": "ElementaryTypeName",
+                                        "src": "64:4:0"
+                                    },
+                                    {
+                                        "attributes": {
+                                            "argumentTypes": null,
+                                            "hexvalue": "31",
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": true,
+                                            "lValueRequested": false,
+                                            "subdenomination": null,
+                                            "token": "number",
+                                            "type": "int_const 1",
+                                            "value": "1"
+                                        },
+                                        "id": 3,
+                                        "name": "Literal",
+                                        "src": "80:1:0"
+                                    }
+                                ],
+                                "id": 4,
+                                "name": "VariableDeclaration",
+                                "src": "64:17:0"
+                            }
+                        ],
+                        "id": 5,
+                        "name": "ContractDefinition",
+                        "src": "25:59:0"
+                    }
+                ],
+                "id": 6,
+                "name": "SourceUnit",
+                "src": "0:85:0"
+            }
+        }
+    },
+    "version": "0.4.13+commit.0fb4cb1a.Linux.g++"
+}


### PR DESCRIPTION
Example:
```bash

> tests@1.0.0 validate-dirs /home/s0b0lev/work/SWC-registry/scripts
> node dir_structure.js

Solc output config is missing for: ../test_cases/solidity/outdated_compiler_version/version_0_4_13/version_0_4_13.sol
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! tests@1.0.0 validate-dirs: `node dir_structure.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the tests@1.0.0 validate-dirs script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/s0b0lev/.npm/_logs/2019-03-28T09_55_44_479Z-debug.log

```