### PR TITLE
Remove attack example from modifier_reentrancy

### DIFF
--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.json
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.json
@@ -1,2022 +1,1108 @@
-{
-  "contracts" : 
-  {
-    "modifier_reentrancy.sol:Bank" : 
-    {
-      "bin" : "608060405234801561001057600080fd5b5061014e806100206000396000f300608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680634d5f327c14610046575b600080fd5b34801561005257600080fd5b5061005b610079565b60405180826000191660001916815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040526040518082805190602001908083835b6020831015156100f057805182526020820191506020810190506020830392506100cb565b6001836020036101000a03801982511681845116808217855250505050505090500191505060405180910390209050905600a165627a7a723058207152ba82349916c4659e46047a5f62edb4cef11b68bc10de66bed1882170bb090029",
-      "bin-runtime" : "608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680634d5f327c14610046575b600080fd5b34801561005257600080fd5b5061005b610079565b60405180826000191660001916815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040526040518082805190602001908083835b6020831015156100f057805182526020820191506020810190506020830392506100cb565b6001836020036101000a03801982511681845116808217855250505050505090500191505060405180910390209050905600a165627a7a723058207152ba82349916c4659e46047a5f62edb4cef11b68bc10de66bed1882170bb090029",
-      "srcmap" : "650:140:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;650:140:0;;;;;;;",
-      "srcmap-runtime" : "650:140:0:-;;;;;;;;;;;;;;;;;;;;;;;;669:119;;8:9:-1;5:2;;;30:1;27;20:12;5:2;669:119:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;716:7;751:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;751:28:0;;;741:39;;;;;;;;;;;;;36:153:-1;66:2;61:3;58:11;51:19;36:153;;;182:3;176:10;171:3;164:23;98:2;93:3;89:12;82:19;;123:2;118:3;114:12;107:19;;148:2;143:3;139:12;132:19;;36:153;;;274:1;267:3;263:2;259:12;254:3;250:22;246:30;315:4;311:9;305:3;299:10;295:26;356:4;350:3;344:10;340:21;389:7;380;377:20;372:3;365:33;3:399;;;741:39:0;;;;;;;;;;;;;;;;734:47;;669:119;:::o"
-    },
-    "modifier_reentrancy.sol:ModifierEntrancy" : 
-    {
-      "bin" : "608060405234801561001057600080fd5b506102f4806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063ca5d088014610051578063eedc966a14610068575b600080fd5b34801561005d57600080fd5b506100666100bf565b005b34801561007457600080fd5b506100a9600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506102b0565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205414151561010c57600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b15801561017057600080fd5b505af1158015610184573d6000803e3d6000fd5b505050506040513d602081101561019a57600080fd5b81019080805190602001909291905050506000191660405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040526040518082805190602001908083835b60208310151561022457805182526020820191506020810190506020830392506101ff565b6001836020036101000a03801982511681845116808217855250505050505090500191505060405180910390206000191614151561026157600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b600060205280600052604060002060009150905054815600a165627a7a7230582010fa64b549bd7ca2c32d19c93cd7595a8bf2bd309f325440d18102a85181b6400029",
-      "bin-runtime" : "60806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063ca5d088014610051578063eedc966a14610068575b600080fd5b34801561005d57600080fd5b506100666100bf565b005b34801561007457600080fd5b506100a9600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506102b0565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205414151561010c57600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401602060405180830381600087803b15801561017057600080fd5b505af1158015610184573d6000803e3d6000fd5b505050506040513d602081101561019a57600080fd5b81019080805190602001909291905050506000191660405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040526040518082805190602001908083835b60208310151561022457805182526020820191506020810190506020830392506101ff565b6001836020036101000a03801982511681845116808217855250505050505090500191505060405180910390206000191614151561026157600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b600060205280600052604060002060009150905054815600a165627a7a7230582010fa64b549bd7ca2c32d19c93cd7595a8bf2bd309f325440d18102a85181b6400029",
-      "srcmap" : "26:622:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;26:622:0;;;;;;;",
-      "srcmap-runtime" : "26:622:0:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;224:94;;8:9:-1;5:2;;;30:1;27;20:12;5:2;224:94:0;;;;;;56:45;;8:9:-1;5:2;;;30:1;27;20:12;5:2;56:45:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;224:94;630:1;602:12;:24;615:10;602:24;;;;;;;;;;;;;;;;:29;594:38;;;;;;;;463:10;458:30;;;:32;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;458:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;458:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;458:32:0;;;;;;;;;;;;;;;;415:75;;;425:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;425:28:0;;;415:39;;;;;;;;;;;;;36:153:-1;66:2;61:3;58:11;51:19;36:153;;;182:3;176:10;171:3;164:23;98:2;93:3;89:12;82:19;;123:2;118:3;114:12;107:19;;148:2;143:3;139:12;132:19;;36:153;;;274:1;267:3;263:2;259:12;254:3;250:22;246:30;315:4;311:9;305:3;299:10;295:26;356:4;350:3;344:10;340:21;389:7;380;377:20;372:3;365:33;3:399;;;415:39:0;;;;;;;;;;;;;;;;:75;;;;407:84;;;;;;;;311:2;283:12;:24;296:10;283:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;224:94::o;56:45::-;;;;;;;;;;;;;;;;;:::o"
-    },
-    "modifier_reentrancy.sol:attack" : 
-    {
-      "bin" : "608060405234801561001057600080fd5b506102c7806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680634d5f327c14610051578063f55332ab14610084575b600080fd5b34801561005d57600080fd5b506100666100c7565b60405180826000191660001916815260200191505060405180910390f35b34801561009057600080fd5b506100c5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061021c565b005b60008060009054906101000a900460ff1615156101755760016000806101000a81548160ff0219169083151502179055503373ffffffffffffffffffffffffffffffffffffffff1663ca5d08806040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401600060405180830381600087803b15801561015c57600080fd5b505af1158015610170573d6000803e3d6000fd5b505050505b60405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040526040518082805190602001908083835b6020831015156101ea57805182526020820191506020810190506020830392506101c5565b6001836020036101000a0380198251168184511680821785525050505050509050019150506040518091039020905090565b8073ffffffffffffffffffffffffffffffffffffffff1663ca5d08806040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401600060405180830381600087803b15801561028057600080fd5b505af1158015610294573d6000803e3d6000fd5b50505050505600a165627a7a723058201ea77e490057932c7f3e47f4cca5277c82d8093dc582aef3faeb018b41ebef160029",
-      "bin-runtime" : "60806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680634d5f327c14610051578063f55332ab14610084575b600080fd5b34801561005d57600080fd5b506100666100c7565b60405180826000191660001916815260200191505060405180910390f35b34801561009057600080fd5b506100c5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061021c565b005b60008060009054906101000a900460ff1615156101755760016000806101000a81548160ff0219169083151502179055503373ffffffffffffffffffffffffffffffffffffffff1663ca5d08806040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401600060405180830381600087803b15801561015c57600080fd5b505af1158015610170573d6000803e3d6000fd5b505050505b60405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040526040518082805190602001908083835b6020831015156101ea57805182526020820191506020810190506020830392506101c5565b6001836020036101000a0380198251168184511680821785525050505050509050019150506040518091039020905090565b8073ffffffffffffffffffffffffffffffffffffffff1663ca5d08806040518163ffffffff167c0100000000000000000000000000000000000000000000000000000000028152600401600060405180830381600087803b15801561028057600080fd5b505af1158015610294573d6000803e3d6000fd5b50505050505600a165627a7a723058201ea77e490057932c7f3e47f4cca5277c82d8093dc582aef3faeb018b41ebef160029",
-      "srcmap" : "792:375:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;792:375:0;;;;;;;",
-      "srcmap-runtime" : "792:375:0:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;837:238;;8:9:-1;5:2;;;30:1;27;20:12;5:2;837:238:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1080:85;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1080:85:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;837:238;879:7;901:13;;;;;;;;;;;900:14;897:115;;;945:4;929:13;;:20;;;;;;;;;;;;;;;;;;980:10;963:36;;;:38;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;963:38:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;963:38:0;;;;897:115;1038:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;1038:28:0;;;1028:39;;;;;;;;;;;;;36:153:-1;66:2;61:3;58:11;51:19;36:153;;;182:3;176:10;171:3;164:23;98:2;93:3;89:12;82:19;;123:2;118:3;114:12;107:19;;148:2;143:3;139:12;132:19;;36:153;;;274:1;267:3;263:2;259:12;254:3;250:22;246:30;315:4;311:9;305:3;299:10;295:26;356:4;350:3;344:10;340:21;389:7;380;377:20;372:3;365:33;3:399;;;1028:39:0;;;;;;;;;;;;;;;;1021:47;;837:238;:::o;1080:85::-;1142:5;1125:31;;;:33;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;1125:33:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;1125:33:0;;;;1080:85;:::o"
-    }
-  },
-  "sourceList" : 
-  [
-    "modifier_reentrancy.sol"
-  ],
-  "sources" : 
-  {
-    "modifier_reentrancy.sol" : 
-    {
-      "AST" : 
-      {
-        "attributes" : 
-        {
-          "absolutePath" : "modifier_reentrancy.sol",
-          "exportedSymbols" : 
-          {
-            "Bank" : 
-            [
-              72
-            ],
-            "ModifierEntrancy" : 
-            [
-              57
-            ],
-            "attack" : 
-            [
-              116
-            ]
-          }
+{  
+    "contracts":{  
+        "modifier_reentrancy.sol:ModifierEntrancy":{  
+           "bin":"608060405234801561001057600080fd5b5061024d806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610209565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b815260040160206040518083038186803b15801561012e57600080fd5b505afa158015610142573d6000803e3d6000fd5b505050506040513d602081101561015857600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101ba57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208dd98a51ad2b4cf491fd15e78829d1f68269e6efc7954dce772a2daaa09b129d0029",
+           "bin-runtime":"608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610209565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b815260040160206040518083038186803b15801561012e57600080fd5b505afa158015610142573d6000803e3d6000fd5b505050506040513d602081101561015857600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101ba57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208dd98a51ad2b4cf491fd15e78829d1f68269e6efc7954dce772a2daaa09b129d0029",
+           "srcmap":"25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;",
+           "srcmap-runtime":"25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;;;;;;;;;;;;;;;;;;223:94;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;223:94;617:1;589:12;:24;602:10;589:24;;;;;;;;;;;;;;;;:29;581:38;;;;;;462:10;457:30;;;:32;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;457:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;457:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;457:32:0;;;;;;;;;;;;;;;;424:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;424:28:0;;;414:39;;;;;;:75;406:84;;;;;;310:2;282:12;:24;295:10;282:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;223:94::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
         },
-        "children" : 
-        [
-          {
-            "attributes" : 
-            {
-              "literals" : 
-              [
-                "solidity",
-                "^",
-                "0.4",
-                ".24"
-              ]
-            },
-            "id" : 1,
-            "name" : "PragmaDirective",
-            "src" : "0:24:0"
-          },
-          {
-            "attributes" : 
-            {
-              "baseContracts" : 
-              [
-                null
-              ],
-              "contractDependencies" : 
-              [
-                null
-              ],
-              "contractKind" : "contract",
-              "documentation" : null,
-              "fullyImplemented" : true,
-              "linearizedBaseContracts" : 
-              [
-                57
-              ],
-              "name" : "ModifierEntrancy",
-              "scope" : 117
-            },
-            "children" : 
-            [
-              {
-                "attributes" : 
-                {
-                  "constant" : false,
-                  "name" : "tokenBalance",
-                  "scope" : 57,
-                  "stateVariable" : true,
-                  "storageLocation" : "default",
-                  "type" : "mapping(address => uint256)",
-                  "value" : null,
-                  "visibility" : "public"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "type" : "mapping(address => uint256)"
-                    },
-                    "children" : 
-                    [
-                      {
-                        "attributes" : 
-                        {
-                          "name" : "address",
-                          "type" : "address"
-                        },
-                        "id" : 2,
-                        "name" : "ElementaryTypeName",
-                        "src" : "65:7:0"
-                      },
-                      {
-                        "attributes" : 
-                        {
-                          "name" : "uint",
-                          "type" : "uint256"
-                        },
-                        "id" : 3,
-                        "name" : "ElementaryTypeName",
-                        "src" : "76:4:0"
-                      }
-                    ],
-                    "id" : 4,
-                    "name" : "Mapping",
-                    "src" : "56:25:0"
-                  }
-                ],
-                "id" : 5,
-                "name" : "VariableDeclaration",
-                "src" : "56:45:0"
-              },
-              {
-                "attributes" : 
-                {
-                  "constant" : true,
-                  "name" : "name",
-                  "scope" : 57,
-                  "stateVariable" : true,
-                  "storageLocation" : "default",
-                  "type" : "string",
-                  "visibility" : "internal"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "name" : "string",
-                      "type" : "string"
-                    },
-                    "id" : 6,
-                    "name" : "ElementaryTypeName",
-                    "src" : "105:6:0"
-                  },
-                  {
-                    "attributes" : 
-                    {
-                      "argumentTypes" : null,
-                      "hexvalue" : "4e7520546f6b656e",
-                      "isConstant" : false,
-                      "isLValue" : false,
-                      "isPure" : true,
-                      "lValueRequested" : false,
-                      "subdenomination" : null,
-                      "token" : "string",
-                      "type" : "literal_string \"Nu Token\"",
-                      "value" : "Nu Token"
-                    },
-                    "id" : 7,
-                    "name" : "Literal",
-                    "src" : "128:10:0"
-                  }
-                ],
-                "id" : 8,
-                "name" : "VariableDeclaration",
-                "src" : "105:33:0"
-              },
-              {
-                "attributes" : 
-                {
-                  "constant" : false,
-                  "documentation" : null,
-                  "implemented" : true,
-                  "isConstructor" : false,
-                  "name" : "airDrop",
-                  "payable" : false,
-                  "scope" : 57,
-                  "stateMutability" : "nonpayable",
-                  "superFunction" : null,
-                  "visibility" : "public"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "parameters" : 
-                      [
-                        null
+       "modifier_reentrancy.sol:Bank":{  
+          "bin":"6080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820604ef1ba30e51d37bd823bee7847bd79f487b494fa566450adf2888bda45eb6d0029",
+          "bin-runtime":"6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820604ef1ba30e51d37bd823bee7847bd79f487b494fa566450adf2888bda45eb6d0029",
+          "srcmap":"637:140:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:140:0;;;;;;;",
+          "srcmap-runtime":"637:140:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:140:0;;;;;;;;;;;;;;;;;;;656:119;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;703:7;738:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;738:28:0;;;728:39;;;;;;721:47;;656:119;:::o"
+       }
+    },
+    "sourceList":[  
+       "modifier_reentrancy.sol"
+    ],
+    "sources":{  
+       "modifier_reentrancy.sol":{  
+          "AST":{  
+             "attributes":{  
+                "absolutePath":"modifier_reentrancy.sol",
+                "exportedSymbols":{  
+                   "Bank":[  
+                      72
+                   ],
+                   "ModifierEntrancy":[  
+                      57
+                   ]
+                }
+             },
+             "children":[  
+                {  
+                   "attributes":{  
+                      "literals":[  
+                         "solidity",
+                         "^",
+                         "0.5",
+                         ".0"
                       ]
-                    },
-                    "children" : [],
-                    "id" : 9,
-                    "name" : "ParameterList",
-                    "src" : "240:2:0"
-                  },
-                  {
-                    "attributes" : 
-                    {
-                      "parameters" : 
-                      [
-                        null
-                      ]
-                    },
-                    "children" : [],
-                    "id" : 14,
-                    "name" : "ParameterList",
-                    "src" : "277:0:0"
-                  },
-                  {
-                    "attributes" : 
-                    {
-                      "arguments" : null
-                    },
-                    "children" : 
-                    [
-                      {
-                        "attributes" : 
-                        {
-                          "argumentTypes" : null,
-                          "overloadedDeclarations" : 
-                          [
-                            null
-                          ],
-                          "referencedDeclaration" : 56,
-                          "type" : "modifier ()",
-                          "value" : "hasNoBalance"
-                        },
-                        "id" : 10,
-                        "name" : "Identifier",
-                        "src" : "243:12:0"
-                      }
-                    ],
-                    "id" : 11,
-                    "name" : "ModifierInvocation",
-                    "src" : "243:12:0"
-                  },
-                  {
-                    "attributes" : 
-                    {
-                      "arguments" : null
-                    },
-                    "children" : 
-                    [
-                      {
-                        "attributes" : 
-                        {
-                          "argumentTypes" : null,
-                          "overloadedDeclarations" : 
-                          [
-                            null
-                          ],
-                          "referencedDeclaration" : 43,
-                          "type" : "modifier ()",
-                          "value" : "supportsToken"
-                        },
-                        "id" : 12,
-                        "name" : "Identifier",
-                        "src" : "256:13:0"
-                      }
-                    ],
-                    "id" : 13,
-                    "name" : "ModifierInvocation",
-                    "src" : "256:13:0"
-                  },
-                  {
-                    "children" : 
-                    [
-                      {
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "isConstant" : false,
-                              "isLValue" : false,
-                              "isPure" : false,
-                              "lValueRequested" : false,
-                              "operator" : "+=",
-                              "type" : "uint256"
-                            },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "isConstant" : false,
-                                  "isLValue" : true,
-                                  "isPure" : false,
-                                  "lValueRequested" : true,
-                                  "type" : "uint256"
-                                },
-                                "children" : 
-                                [
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "overloadedDeclarations" : 
-                                      [
-                                        null
-                                      ],
-                                      "referencedDeclaration" : 5,
-                                      "type" : "mapping(address => uint256)",
-                                      "value" : "tokenBalance"
-                                    },
-                                    "id" : 15,
-                                    "name" : "Identifier",
-                                    "src" : "283:12:0"
+                   },
+                   "id":1,
+                   "name":"PragmaDirective",
+                   "src":"0:23:0"
+                },
+                {  
+                   "attributes":{  
+                      "baseContracts":[  
+                         null
+                      ],
+                      "contractDependencies":[  
+                         null
+                      ],
+                      "contractKind":"contract",
+                      "documentation":null,
+                      "fullyImplemented":true,
+                      "linearizedBaseContracts":[  
+                         57
+                      ],
+                      "name":"ModifierEntrancy",
+                      "scope":73
+                   },
+                   "children":[  
+                      {  
+                         "attributes":{  
+                            "constant":false,
+                            "name":"tokenBalance",
+                            "scope":57,
+                            "stateVariable":true,
+                            "storageLocation":"default",
+                            "type":"mapping(address => uint256)",
+                            "value":null,
+                            "visibility":"public"
+                         },
+                         "children":[  
+                            {  
+                               "attributes":{  
+                                  "type":"mapping(address => uint256)"
+                               },
+                               "children":[  
+                                  {  
+                                     "attributes":{  
+                                        "name":"address",
+                                        "type":"address"
+                                     },
+                                     "id":2,
+                                     "name":"ElementaryTypeName",
+                                     "src":"64:7:0"
                                   },
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : false,
-                                      "lValueRequested" : false,
-                                      "member_name" : "sender",
-                                      "referencedDeclaration" : null,
-                                      "type" : "address"
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "overloadedDeclarations" : 
-                                          [
-                                            null
-                                          ],
-                                          "referencedDeclaration" : 131,
-                                          "type" : "msg",
-                                          "value" : "msg"
-                                        },
-                                        "id" : 16,
-                                        "name" : "Identifier",
-                                        "src" : "296:3:0"
-                                      }
-                                    ],
-                                    "id" : 17,
-                                    "name" : "MemberAccess",
-                                    "src" : "296:10:0"
+                                  {  
+                                     "attributes":{  
+                                        "name":"uint",
+                                        "type":"uint256"
+                                     },
+                                     "id":3,
+                                     "name":"ElementaryTypeName",
+                                     "src":"75:4:0"
                                   }
-                                ],
-                                "id" : 18,
-                                "name" : "IndexAccess",
-                                "src" : "283:24:0"
-                              },
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "hexvalue" : "3230",
-                                  "isConstant" : false,
-                                  "isLValue" : false,
-                                  "isPure" : true,
-                                  "lValueRequested" : false,
-                                  "subdenomination" : null,
-                                  "token" : "number",
-                                  "type" : "int_const 20",
-                                  "value" : "20"
-                                },
-                                "id" : 19,
-                                "name" : "Literal",
-                                "src" : "311:2:0"
-                              }
-                            ],
-                            "id" : 20,
-                            "name" : "Assignment",
-                            "src" : "283:30:0"
-                          }
-                        ],
-                        "id" : 21,
-                        "name" : "ExpressionStatement",
-                        "src" : "283:30:0"
-                      }
-                    ],
-                    "id" : 22,
-                    "name" : "Block",
-                    "src" : "277:41:0"
-                  }
-                ],
-                "id" : 23,
-                "name" : "FunctionDefinition",
-                "src" : "224:94:0"
-              },
-              {
-                "attributes" : 
-                {
-                  "documentation" : null,
-                  "name" : "supportsToken",
-                  "visibility" : "internal"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "parameters" : 
-                      [
-                        null
-                      ]
-                    },
-                    "children" : [],
-                    "id" : 24,
-                    "name" : "ParameterList",
-                    "src" : "398:2:0"
-                  },
-                  {
-                    "children" : 
-                    [
-                      {
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "isConstant" : false,
-                              "isLValue" : false,
-                              "isPure" : false,
-                              "isStructConstructorCall" : false,
-                              "lValueRequested" : false,
-                              "names" : 
-                              [
-                                null
-                              ],
-                              "type" : "tuple()",
-                              "type_conversion" : false
+                               ],
+                               "id":4,
+                               "name":"Mapping",
+                               "src":"55:25:0"
+                            }
+                         ],
+                         "id":5,
+                         "name":"VariableDeclaration",
+                         "src":"55:45:0"
+                      },
+                      {  
+                         "attributes":{  
+                            "constant":true,
+                            "name":"name",
+                            "scope":57,
+                            "stateVariable":true,
+                            "storageLocation":"default",
+                            "type":"string",
+                            "visibility":"internal"
+                         },
+                         "children":[  
+                            {  
+                               "attributes":{  
+                                  "name":"string",
+                                  "type":"string"
+                               },
+                               "id":6,
+                               "name":"ElementaryTypeName",
+                               "src":"104:6:0"
                             },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : 
-                                  [
-                                    {
-                                      "typeIdentifier" : "t_bool",
-                                      "typeString" : "bool"
-                                    }
-                                  ],
-                                  "overloadedDeclarations" : 
-                                  [
-                                    134,
-                                    135
-                                  ],
-                                  "referencedDeclaration" : 134,
-                                  "type" : "function (bool) pure",
-                                  "value" : "require"
-                                },
-                                "id" : 25,
-                                "name" : "Identifier",
-                                "src" : "407:7:0"
-                              },
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "commonType" : 
-                                  {
-                                    "typeIdentifier" : "t_bytes32",
-                                    "typeString" : "bytes32"
-                                  },
-                                  "isConstant" : false,
-                                  "isLValue" : false,
-                                  "isPure" : false,
-                                  "lValueRequested" : false,
-                                  "operator" : "==",
-                                  "type" : "bool"
-                                },
-                                "children" : 
-                                [
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : true,
-                                      "isStructConstructorCall" : false,
-                                      "lValueRequested" : false,
-                                      "names" : 
-                                      [
-                                        null
-                                      ],
-                                      "type" : "bytes32",
-                                      "type_conversion" : false
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : 
-                                          [
-                                            {
-                                              "typeIdentifier" : "t_bytes_memory_ptr",
-                                              "typeString" : "bytes memory"
-                                            }
-                                          ],
-                                          "overloadedDeclarations" : 
-                                          [
-                                            null
-                                          ],
-                                          "referencedDeclaration" : 125,
-                                          "type" : "function () pure returns (bytes32)",
-                                          "value" : "keccak256"
-                                        },
-                                        "id" : 26,
-                                        "name" : "Identifier",
-                                        "src" : "415:9:0"
-                                      },
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : true,
-                                          "isStructConstructorCall" : false,
-                                          "lValueRequested" : false,
-                                          "names" : 
-                                          [
-                                            null
-                                          ],
-                                          "type" : "bytes memory",
-                                          "type_conversion" : false
-                                        },
-                                        "children" : 
-                                        [
-                                          {
-                                            "attributes" : 
-                                            {
-                                              "argumentTypes" : 
-                                              [
-                                                {
-                                                  "typeIdentifier" : "t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
-                                                  "typeString" : "literal_string \"Nu Token\""
-                                                }
-                                              ],
-                                              "isConstant" : false,
-                                              "isLValue" : false,
-                                              "isPure" : true,
-                                              "lValueRequested" : false,
-                                              "member_name" : "encodePacked",
-                                              "referencedDeclaration" : null,
-                                              "type" : "function () pure returns (bytes memory)"
-                                            },
-                                            "children" : 
-                                            [
-                                              {
-                                                "attributes" : 
-                                                {
-                                                  "argumentTypes" : null,
-                                                  "overloadedDeclarations" : 
-                                                  [
-                                                    null
-                                                  ],
-                                                  "referencedDeclaration" : 118,
-                                                  "type" : "abi",
-                                                  "value" : "abi"
-                                                },
-                                                "id" : 27,
-                                                "name" : "Identifier",
-                                                "src" : "425:3:0"
-                                              }
-                                            ],
-                                            "id" : 28,
-                                            "name" : "MemberAccess",
-                                            "src" : "425:16:0"
-                                          },
-                                          {
-                                            "attributes" : 
-                                            {
-                                              "argumentTypes" : null,
-                                              "hexvalue" : "4e7520546f6b656e",
-                                              "isConstant" : false,
-                                              "isLValue" : false,
-                                              "isPure" : true,
-                                              "lValueRequested" : false,
-                                              "subdenomination" : null,
-                                              "token" : "string",
-                                              "type" : "literal_string \"Nu Token\"",
-                                              "value" : "Nu Token"
-                                            },
-                                            "id" : 29,
-                                            "name" : "Literal",
-                                            "src" : "442:10:0"
-                                          }
+                            {  
+                               "attributes":{  
+                                  "argumentTypes":null,
+                                  "hexvalue":"4e7520546f6b656e",
+                                  "isConstant":false,
+                                  "isLValue":false,
+                                  "isPure":true,
+                                  "lValueRequested":false,
+                                  "subdenomination":null,
+                                  "token":"string",
+                                  "type":"literal_string \"Nu Token\"",
+                                  "value":"Nu Token"
+                               },
+                               "id":7,
+                               "name":"Literal",
+                               "src":"127:10:0"
+                            }
+                         ],
+                         "id":8,
+                         "name":"VariableDeclaration",
+                         "src":"104:33:0"
+                      },
+                      {  
+                         "attributes":{  
+                            "documentation":null,
+                            "implemented":true,
+                            "isConstructor":false,
+                            "kind":"function",
+                            "name":"airDrop",
+                            "scope":57,
+                            "stateMutability":"nonpayable",
+                            "superFunction":null,
+                            "visibility":"public"
+                         },
+                         "children":[  
+                            {  
+                               "attributes":{  
+                                  "parameters":[  
+                                     null
+                                  ]
+                               },
+                               "children":[  
+ 
+                               ],
+                               "id":9,
+                               "name":"ParameterList",
+                               "src":"239:2:0"
+                            },
+                            {  
+                               "attributes":{  
+                                  "parameters":[  
+                                     null
+                                  ]
+                               },
+                               "children":[  
+ 
+                               ],
+                               "id":14,
+                               "name":"ParameterList",
+                               "src":"276:0:0"
+                            },
+                            {  
+                               "attributes":{  
+                                  "arguments":null
+                               },
+                               "children":[  
+                                  {  
+                                     "attributes":{  
+                                        "argumentTypes":null,
+                                        "overloadedDeclarations":[  
+                                           null
                                         ],
-                                        "id" : 30,
-                                        "name" : "FunctionCall",
-                                        "src" : "425:28:0"
-                                      }
-                                    ],
-                                    "id" : 31,
-                                    "name" : "FunctionCall",
-                                    "src" : "415:39:0"
-                                  },
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "arguments" : 
-                                      [
-                                        null
-                                      ],
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : false,
-                                      "isStructConstructorCall" : false,
-                                      "lValueRequested" : false,
-                                      "names" : 
-                                      [
-                                        null
-                                      ],
-                                      "type" : "bytes32",
-                                      "type_conversion" : false
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : 
-                                          [
-                                            null
-                                          ],
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : false,
-                                          "lValueRequested" : false,
-                                          "member_name" : "supportsToken",
-                                          "referencedDeclaration" : 71,
-                                          "type" : "function () pure external returns (bytes32)"
-                                        },
-                                        "children" : 
-                                        [
-                                          {
-                                            "attributes" : 
-                                            {
-                                              "argumentTypes" : null,
-                                              "isConstant" : false,
-                                              "isLValue" : false,
-                                              "isPure" : false,
-                                              "isStructConstructorCall" : false,
-                                              "lValueRequested" : false,
-                                              "names" : 
-                                              [
-                                                null
-                                              ],
-                                              "type" : "contract Bank",
-                                              "type_conversion" : true
-                                            },
-                                            "children" : 
-                                            [
-                                              {
-                                                "attributes" : 
-                                                {
-                                                  "argumentTypes" : 
-                                                  [
-                                                    {
-                                                      "typeIdentifier" : "t_address",
-                                                      "typeString" : "address"
-                                                    }
-                                                  ],
-                                                  "overloadedDeclarations" : 
-                                                  [
-                                                    null
-                                                  ],
-                                                  "referencedDeclaration" : 72,
-                                                  "type" : "type(contract Bank)",
-                                                  "value" : "Bank"
-                                                },
-                                                "id" : 32,
-                                                "name" : "Identifier",
-                                                "src" : "458:4:0"
-                                              },
-                                              {
-                                                "attributes" : 
-                                                {
-                                                  "argumentTypes" : null,
-                                                  "isConstant" : false,
-                                                  "isLValue" : false,
-                                                  "isPure" : false,
-                                                  "lValueRequested" : false,
-                                                  "member_name" : "sender",
-                                                  "referencedDeclaration" : null,
-                                                  "type" : "address"
-                                                },
-                                                "children" : 
-                                                [
-                                                  {
-                                                    "attributes" : 
-                                                    {
-                                                      "argumentTypes" : null,
-                                                      "overloadedDeclarations" : 
-                                                      [
-                                                        null
-                                                      ],
-                                                      "referencedDeclaration" : 131,
-                                                      "type" : "msg",
-                                                      "value" : "msg"
+                                        "referencedDeclaration":56,
+                                        "type":"modifier ()",
+                                        "value":"hasNoBalance"
+                                     },
+                                     "id":10,
+                                     "name":"Identifier",
+                                     "src":"242:12:0"
+                                  }
+                               ],
+                               "id":11,
+                               "name":"ModifierInvocation",
+                               "src":"242:12:0"
+                            },
+                            {  
+                               "attributes":{  
+                                  "arguments":null
+                               },
+                               "children":[  
+                                  {  
+                                     "attributes":{  
+                                        "argumentTypes":null,
+                                        "overloadedDeclarations":[  
+                                           null
+                                        ],
+                                        "referencedDeclaration":43,
+                                        "type":"modifier ()",
+                                        "value":"supportsToken"
+                                     },
+                                     "id":12,
+                                     "name":"Identifier",
+                                     "src":"255:13:0"
+                                  }
+                               ],
+                               "id":13,
+                               "name":"ModifierInvocation",
+                               "src":"255:13:0"
+                            },
+                            {  
+                               "children":[  
+                                  {  
+                                     "children":[  
+                                        {  
+                                           "attributes":{  
+                                              "argumentTypes":null,
+                                              "isConstant":false,
+                                              "isLValue":false,
+                                              "isPure":false,
+                                              "lValueRequested":false,
+                                              "operator":"+=",
+                                              "type":"uint256"
+                                           },
+                                           "children":[  
+                                              {  
+                                                 "attributes":{  
+                                                    "argumentTypes":null,
+                                                    "isConstant":false,
+                                                    "isLValue":true,
+                                                    "isPure":false,
+                                                    "lValueRequested":true,
+                                                    "type":"uint256"
+                                                 },
+                                                 "children":[  
+                                                    {  
+                                                       "attributes":{  
+                                                          "argumentTypes":null,
+                                                          "overloadedDeclarations":[  
+                                                             null
+                                                          ],
+                                                          "referencedDeclaration":5,
+                                                          "type":"mapping(address => uint256)",
+                                                          "value":"tokenBalance"
+                                                       },
+                                                       "id":15,
+                                                       "name":"Identifier",
+                                                       "src":"282:12:0"
                                                     },
-                                                    "id" : 33,
-                                                    "name" : "Identifier",
-                                                    "src" : "463:3:0"
-                                                  }
-                                                ],
-                                                "id" : 34,
-                                                "name" : "MemberAccess",
-                                                "src" : "463:10:0"
-                                              }
-                                            ],
-                                            "id" : 35,
-                                            "name" : "FunctionCall",
-                                            "src" : "458:16:0"
-                                          }
-                                        ],
-                                        "id" : 36,
-                                        "name" : "MemberAccess",
-                                        "src" : "458:30:0"
-                                      }
-                                    ],
-                                    "id" : 37,
-                                    "name" : "FunctionCall",
-                                    "src" : "458:32:0"
-                                  }
-                                ],
-                                "id" : 38,
-                                "name" : "BinaryOperation",
-                                "src" : "415:75:0"
-                              }
-                            ],
-                            "id" : 39,
-                            "name" : "FunctionCall",
-                            "src" : "407:84:0"
-                          }
-                        ],
-                        "id" : 40,
-                        "name" : "ExpressionStatement",
-                        "src" : "407:84:0"
-                      },
-                      {
-                        "id" : 41,
-                        "name" : "PlaceholderStatement",
-                        "src" : "497:1:0"
-                      }
-                    ],
-                    "id" : 42,
-                    "name" : "Block",
-                    "src" : "401:102:0"
-                  }
-                ],
-                "id" : 43,
-                "name" : "ModifierDefinition",
-                "src" : "376:127:0"
-              },
-              {
-                "attributes" : 
-                {
-                  "documentation" : null,
-                  "name" : "hasNoBalance",
-                  "visibility" : "internal"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "parameters" : 
-                      [
-                        null
-                      ]
-                    },
-                    "children" : [],
-                    "id" : 44,
-                    "name" : "ParameterList",
-                    "src" : "586:0:0"
-                  },
-                  {
-                    "children" : 
-                    [
-                      {
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "isConstant" : false,
-                              "isLValue" : false,
-                              "isPure" : false,
-                              "isStructConstructorCall" : false,
-                              "lValueRequested" : false,
-                              "names" : 
-                              [
-                                null
-                              ],
-                              "type" : "tuple()",
-                              "type_conversion" : false
-                            },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : 
-                                  [
-                                    {
-                                      "typeIdentifier" : "t_bool",
-                                      "typeString" : "bool"
-                                    }
-                                  ],
-                                  "overloadedDeclarations" : 
-                                  [
-                                    134,
-                                    135
-                                  ],
-                                  "referencedDeclaration" : 134,
-                                  "type" : "function (bool) pure",
-                                  "value" : "require"
-                                },
-                                "id" : 45,
-                                "name" : "Identifier",
-                                "src" : "594:7:0"
-                              },
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "commonType" : 
-                                  {
-                                    "typeIdentifier" : "t_uint256",
-                                    "typeString" : "uint256"
-                                  },
-                                  "isConstant" : false,
-                                  "isLValue" : false,
-                                  "isPure" : false,
-                                  "lValueRequested" : false,
-                                  "operator" : "==",
-                                  "type" : "bool"
-                                },
-                                "children" : 
-                                [
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "isConstant" : false,
-                                      "isLValue" : true,
-                                      "isPure" : false,
-                                      "lValueRequested" : false,
-                                      "type" : "uint256"
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "overloadedDeclarations" : 
-                                          [
-                                            null
-                                          ],
-                                          "referencedDeclaration" : 5,
-                                          "type" : "mapping(address => uint256)",
-                                          "value" : "tokenBalance"
-                                        },
-                                        "id" : 46,
-                                        "name" : "Identifier",
-                                        "src" : "602:12:0"
-                                      },
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : false,
-                                          "lValueRequested" : false,
-                                          "member_name" : "sender",
-                                          "referencedDeclaration" : null,
-                                          "type" : "address"
-                                        },
-                                        "children" : 
-                                        [
-                                          {
-                                            "attributes" : 
-                                            {
-                                              "argumentTypes" : null,
-                                              "overloadedDeclarations" : 
-                                              [
-                                                null
-                                              ],
-                                              "referencedDeclaration" : 131,
-                                              "type" : "msg",
-                                              "value" : "msg"
-                                            },
-                                            "id" : 47,
-                                            "name" : "Identifier",
-                                            "src" : "615:3:0"
-                                          }
-                                        ],
-                                        "id" : 48,
-                                        "name" : "MemberAccess",
-                                        "src" : "615:10:0"
-                                      }
-                                    ],
-                                    "id" : 49,
-                                    "name" : "IndexAccess",
-                                    "src" : "602:24:0"
-                                  },
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "hexvalue" : "30",
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : true,
-                                      "lValueRequested" : false,
-                                      "subdenomination" : null,
-                                      "token" : "number",
-                                      "type" : "int_const 0",
-                                      "value" : "0"
-                                    },
-                                    "id" : 50,
-                                    "name" : "Literal",
-                                    "src" : "630:1:0"
-                                  }
-                                ],
-                                "id" : 51,
-                                "name" : "BinaryOperation",
-                                "src" : "602:29:0"
-                              }
-                            ],
-                            "id" : 52,
-                            "name" : "FunctionCall",
-                            "src" : "594:38:0"
-                          }
-                        ],
-                        "id" : 53,
-                        "name" : "ExpressionStatement",
-                        "src" : "594:38:0"
-                      },
-                      {
-                        "id" : 54,
-                        "name" : "PlaceholderStatement",
-                        "src" : "640:1:0"
-                      }
-                    ],
-                    "id" : 55,
-                    "name" : "Block",
-                    "src" : "586:60:0"
-                  }
-                ],
-                "id" : 56,
-                "name" : "ModifierDefinition",
-                "src" : "564:82:0"
-              }
-            ],
-            "id" : 57,
-            "name" : "ContractDefinition",
-            "src" : "26:622:0"
-          },
-          {
-            "attributes" : 
-            {
-              "baseContracts" : 
-              [
-                null
-              ],
-              "contractDependencies" : 
-              [
-                null
-              ],
-              "contractKind" : "contract",
-              "documentation" : null,
-              "fullyImplemented" : true,
-              "linearizedBaseContracts" : 
-              [
-                72
-              ],
-              "name" : "Bank",
-              "scope" : 117
-            },
-            "children" : 
-            [
-              {
-                "attributes" : 
-                {
-                  "constant" : true,
-                  "documentation" : null,
-                  "implemented" : true,
-                  "isConstructor" : false,
-                  "modifiers" : 
-                  [
-                    null
-                  ],
-                  "name" : "supportsToken",
-                  "payable" : false,
-                  "scope" : 72,
-                  "stateMutability" : "pure",
-                  "superFunction" : null,
-                  "visibility" : "external"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "parameters" : 
-                      [
-                        null
-                      ]
-                    },
-                    "children" : [],
-                    "id" : 58,
-                    "name" : "ParameterList",
-                    "src" : "691:2:0"
-                  },
-                  {
-                    "children" : 
-                    [
-                      {
-                        "attributes" : 
-                        {
-                          "constant" : false,
-                          "name" : "",
-                          "scope" : 71,
-                          "stateVariable" : false,
-                          "storageLocation" : "default",
-                          "type" : "bytes32",
-                          "value" : null,
-                          "visibility" : "internal"
-                        },
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "name" : "bytes32",
-                              "type" : "bytes32"
-                            },
-                            "id" : 59,
-                            "name" : "ElementaryTypeName",
-                            "src" : "716:7:0"
-                          }
-                        ],
-                        "id" : 60,
-                        "name" : "VariableDeclaration",
-                        "src" : "716:7:0"
-                      }
-                    ],
-                    "id" : 61,
-                    "name" : "ParameterList",
-                    "src" : "715:9:0"
-                  },
-                  {
-                    "children" : 
-                    [
-                      {
-                        "attributes" : 
-                        {
-                          "functionReturnParameters" : 61
-                        },
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "isConstant" : false,
-                              "isInlineArray" : false,
-                              "isLValue" : false,
-                              "isPure" : true,
-                              "lValueRequested" : false,
-                              "type" : "bytes32"
-                            },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "isConstant" : false,
-                                  "isLValue" : false,
-                                  "isPure" : true,
-                                  "isStructConstructorCall" : false,
-                                  "lValueRequested" : false,
-                                  "names" : 
-                                  [
-                                    null
-                                  ],
-                                  "type" : "bytes32",
-                                  "type_conversion" : false
-                                },
-                                "children" : 
-                                [
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : 
-                                      [
-                                        {
-                                          "typeIdentifier" : "t_bytes_memory_ptr",
-                                          "typeString" : "bytes memory"
-                                        }
-                                      ],
-                                      "overloadedDeclarations" : 
-                                      [
-                                        null
-                                      ],
-                                      "referencedDeclaration" : 125,
-                                      "type" : "function () pure returns (bytes32)",
-                                      "value" : "keccak256"
-                                    },
-                                    "id" : 62,
-                                    "name" : "Identifier",
-                                    "src" : "741:9:0"
-                                  },
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : true,
-                                      "isStructConstructorCall" : false,
-                                      "lValueRequested" : false,
-                                      "names" : 
-                                      [
-                                        null
-                                      ],
-                                      "type" : "bytes memory",
-                                      "type_conversion" : false
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : 
-                                          [
-                                            {
-                                              "typeIdentifier" : "t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
-                                              "typeString" : "literal_string \"Nu Token\""
-                                            }
-                                          ],
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : true,
-                                          "lValueRequested" : false,
-                                          "member_name" : "encodePacked",
-                                          "referencedDeclaration" : null,
-                                          "type" : "function () pure returns (bytes memory)"
-                                        },
-                                        "children" : 
-                                        [
-                                          {
-                                            "attributes" : 
-                                            {
-                                              "argumentTypes" : null,
-                                              "overloadedDeclarations" : 
-                                              [
-                                                null
-                                              ],
-                                              "referencedDeclaration" : 118,
-                                              "type" : "abi",
-                                              "value" : "abi"
-                                            },
-                                            "id" : 63,
-                                            "name" : "Identifier",
-                                            "src" : "751:3:0"
-                                          }
-                                        ],
-                                        "id" : 64,
-                                        "name" : "MemberAccess",
-                                        "src" : "751:16:0"
-                                      },
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "hexvalue" : "4e7520546f6b656e",
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : true,
-                                          "lValueRequested" : false,
-                                          "subdenomination" : null,
-                                          "token" : "string",
-                                          "type" : "literal_string \"Nu Token\"",
-                                          "value" : "Nu Token"
-                                        },
-                                        "id" : 65,
-                                        "name" : "Literal",
-                                        "src" : "768:10:0"
-                                      }
-                                    ],
-                                    "id" : 66,
-                                    "name" : "FunctionCall",
-                                    "src" : "751:28:0"
-                                  }
-                                ],
-                                "id" : 67,
-                                "name" : "FunctionCall",
-                                "src" : "741:39:0"
-                              }
-                            ],
-                            "id" : 68,
-                            "name" : "TupleExpression",
-                            "src" : "740:41:0"
-                          }
-                        ],
-                        "id" : 69,
-                        "name" : "Return",
-                        "src" : "734:47:0"
-                      }
-                    ],
-                    "id" : 70,
-                    "name" : "Block",
-                    "src" : "724:64:0"
-                  }
-                ],
-                "id" : 71,
-                "name" : "FunctionDefinition",
-                "src" : "669:119:0"
-              }
-            ],
-            "id" : 72,
-            "name" : "ContractDefinition",
-            "src" : "650:140:0"
-          },
-          {
-            "attributes" : 
-            {
-              "baseContracts" : 
-              [
-                null
-              ],
-              "contractDependencies" : 
-              [
-                null
-              ],
-              "contractKind" : "contract",
-              "documentation" : null,
-              "fullyImplemented" : true,
-              "linearizedBaseContracts" : 
-              [
-                116
-              ],
-              "name" : "attack",
-              "scope" : 117
-            },
-            "children" : 
-            [
-              {
-                "attributes" : 
-                {
-                  "constant" : false,
-                  "name" : "hasBeenCalled",
-                  "scope" : 116,
-                  "stateVariable" : true,
-                  "storageLocation" : "default",
-                  "type" : "bool",
-                  "value" : null,
-                  "visibility" : "internal"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "name" : "bool",
-                      "type" : "bool"
-                    },
-                    "id" : 73,
-                    "name" : "ElementaryTypeName",
-                    "src" : "813:4:0"
-                  }
-                ],
-                "id" : 74,
-                "name" : "VariableDeclaration",
-                "src" : "813:18:0"
-              },
-              {
-                "attributes" : 
-                {
-                  "constant" : false,
-                  "documentation" : null,
-                  "implemented" : true,
-                  "isConstructor" : false,
-                  "modifiers" : 
-                  [
-                    null
-                  ],
-                  "name" : "supportsToken",
-                  "payable" : false,
-                  "scope" : 116,
-                  "stateMutability" : "nonpayable",
-                  "superFunction" : null,
-                  "visibility" : "external"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "parameters" : 
-                      [
-                        null
-                      ]
-                    },
-                    "children" : [],
-                    "id" : 75,
-                    "name" : "ParameterList",
-                    "src" : "859:2:0"
-                  },
-                  {
-                    "children" : 
-                    [
-                      {
-                        "attributes" : 
-                        {
-                          "constant" : false,
-                          "name" : "",
-                          "scope" : 103,
-                          "stateVariable" : false,
-                          "storageLocation" : "default",
-                          "type" : "bytes32",
-                          "value" : null,
-                          "visibility" : "internal"
-                        },
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "name" : "bytes32",
-                              "type" : "bytes32"
-                            },
-                            "id" : 76,
-                            "name" : "ElementaryTypeName",
-                            "src" : "879:7:0"
-                          }
-                        ],
-                        "id" : 77,
-                        "name" : "VariableDeclaration",
-                        "src" : "879:7:0"
-                      }
-                    ],
-                    "id" : 78,
-                    "name" : "ParameterList",
-                    "src" : "878:9:0"
-                  },
-                  {
-                    "children" : 
-                    [
-                      {
-                        "attributes" : 
-                        {
-                          "falseBody" : null
-                        },
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "isConstant" : false,
-                              "isLValue" : false,
-                              "isPure" : false,
-                              "lValueRequested" : false,
-                              "operator" : "!",
-                              "prefix" : true,
-                              "type" : "bool"
-                            },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "overloadedDeclarations" : 
-                                  [
-                                    null
-                                  ],
-                                  "referencedDeclaration" : 74,
-                                  "type" : "bool",
-                                  "value" : "hasBeenCalled"
-                                },
-                                "id" : 79,
-                                "name" : "Identifier",
-                                "src" : "901:13:0"
-                              }
-                            ],
-                            "id" : 80,
-                            "name" : "UnaryOperation",
-                            "src" : "900:14:0"
-                          },
-                          {
-                            "children" : 
-                            [
-                              {
-                                "children" : 
-                                [
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : false,
-                                      "lValueRequested" : false,
-                                      "operator" : "=",
-                                      "type" : "bool"
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "overloadedDeclarations" : 
-                                          [
-                                            null
-                                          ],
-                                          "referencedDeclaration" : 74,
-                                          "type" : "bool",
-                                          "value" : "hasBeenCalled"
-                                        },
-                                        "id" : 81,
-                                        "name" : "Identifier",
-                                        "src" : "929:13:0"
-                                      },
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "hexvalue" : "74727565",
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : true,
-                                          "lValueRequested" : false,
-                                          "subdenomination" : null,
-                                          "token" : "bool",
-                                          "type" : "bool",
-                                          "value" : "true"
-                                        },
-                                        "id" : 82,
-                                        "name" : "Literal",
-                                        "src" : "945:4:0"
-                                      }
-                                    ],
-                                    "id" : 83,
-                                    "name" : "Assignment",
-                                    "src" : "929:20:0"
-                                  }
-                                ],
-                                "id" : 84,
-                                "name" : "ExpressionStatement",
-                                "src" : "929:20:0"
-                              },
-                              {
-                                "children" : 
-                                [
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "arguments" : 
-                                      [
-                                        null
-                                      ],
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : false,
-                                      "isStructConstructorCall" : false,
-                                      "lValueRequested" : false,
-                                      "names" : 
-                                      [
-                                        null
-                                      ],
-                                      "type" : "tuple()",
-                                      "type_conversion" : false
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : 
-                                          [
-                                            null
-                                          ],
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : false,
-                                          "lValueRequested" : false,
-                                          "member_name" : "airDrop",
-                                          "referencedDeclaration" : 23,
-                                          "type" : "function () external"
-                                        },
-                                        "children" : 
-                                        [
-                                          {
-                                            "attributes" : 
-                                            {
-                                              "argumentTypes" : null,
-                                              "isConstant" : false,
-                                              "isLValue" : false,
-                                              "isPure" : false,
-                                              "isStructConstructorCall" : false,
-                                              "lValueRequested" : false,
-                                              "names" : 
-                                              [
-                                                null
-                                              ],
-                                              "type" : "contract ModifierEntrancy",
-                                              "type_conversion" : true
-                                            },
-                                            "children" : 
-                                            [
-                                              {
-                                                "attributes" : 
-                                                {
-                                                  "argumentTypes" : 
-                                                  [
-                                                    {
-                                                      "typeIdentifier" : "t_address",
-                                                      "typeString" : "address"
+                                                    {  
+                                                       "attributes":{  
+                                                          "argumentTypes":null,
+                                                          "isConstant":false,
+                                                          "isLValue":false,
+                                                          "isPure":false,
+                                                          "lValueRequested":false,
+                                                          "member_name":"sender",
+                                                          "referencedDeclaration":null,
+                                                          "type":"address payable"
+                                                       },
+                                                       "children":[  
+                                                          {  
+                                                             "attributes":{  
+                                                                "argumentTypes":null,
+                                                                "overloadedDeclarations":[  
+                                                                   null
+                                                                ],
+                                                                "referencedDeclaration":87,
+                                                                "type":"msg",
+                                                                "value":"msg"
+                                                             },
+                                                             "id":16,
+                                                             "name":"Identifier",
+                                                             "src":"295:3:0"
+                                                          }
+                                                       ],
+                                                       "id":17,
+                                                       "name":"MemberAccess",
+                                                       "src":"295:10:0"
                                                     }
-                                                  ],
-                                                  "overloadedDeclarations" : 
-                                                  [
-                                                    null
-                                                  ],
-                                                  "referencedDeclaration" : 57,
-                                                  "type" : "type(contract ModifierEntrancy)",
-                                                  "value" : "ModifierEntrancy"
-                                                },
-                                                "id" : 85,
-                                                "name" : "Identifier",
-                                                "src" : "963:16:0"
+                                                 ],
+                                                 "id":18,
+                                                 "name":"IndexAccess",
+                                                 "src":"282:24:0"
                                               },
-                                              {
-                                                "attributes" : 
-                                                {
-                                                  "argumentTypes" : null,
-                                                  "isConstant" : false,
-                                                  "isLValue" : false,
-                                                  "isPure" : false,
-                                                  "lValueRequested" : false,
-                                                  "member_name" : "sender",
-                                                  "referencedDeclaration" : null,
-                                                  "type" : "address"
-                                                },
-                                                "children" : 
-                                                [
-                                                  {
-                                                    "attributes" : 
-                                                    {
-                                                      "argumentTypes" : null,
-                                                      "overloadedDeclarations" : 
-                                                      [
-                                                        null
-                                                      ],
-                                                      "referencedDeclaration" : 131,
-                                                      "type" : "msg",
-                                                      "value" : "msg"
-                                                    },
-                                                    "id" : 86,
-                                                    "name" : "Identifier",
-                                                    "src" : "980:3:0"
-                                                  }
-                                                ],
-                                                "id" : 87,
-                                                "name" : "MemberAccess",
-                                                "src" : "980:10:0"
+                                              {  
+                                                 "attributes":{  
+                                                    "argumentTypes":null,
+                                                    "hexvalue":"3230",
+                                                    "isConstant":false,
+                                                    "isLValue":false,
+                                                    "isPure":true,
+                                                    "lValueRequested":false,
+                                                    "subdenomination":null,
+                                                    "token":"number",
+                                                    "type":"int_const 20",
+                                                    "value":"20"
+                                                 },
+                                                 "id":19,
+                                                 "name":"Literal",
+                                                 "src":"310:2:0"
                                               }
-                                            ],
-                                            "id" : 88,
-                                            "name" : "FunctionCall",
-                                            "src" : "963:28:0"
-                                          }
-                                        ],
-                                        "id" : 89,
-                                        "name" : "MemberAccess",
-                                        "src" : "963:36:0"
-                                      }
-                                    ],
-                                    "id" : 90,
-                                    "name" : "FunctionCall",
-                                    "src" : "963:38:0"
-                                  }
-                                ],
-                                "id" : 91,
-                                "name" : "ExpressionStatement",
-                                "src" : "963:38:0"
-                              }
-                            ],
-                            "id" : 92,
-                            "name" : "Block",
-                            "src" : "915:97:0"
-                          }
-                        ],
-                        "id" : 93,
-                        "name" : "IfStatement",
-                        "src" : "897:115:0"
-                      },
-                      {
-                        "attributes" : 
-                        {
-                          "functionReturnParameters" : 78
-                        },
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "isConstant" : false,
-                              "isInlineArray" : false,
-                              "isLValue" : false,
-                              "isPure" : true,
-                              "lValueRequested" : false,
-                              "type" : "bytes32"
-                            },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "isConstant" : false,
-                                  "isLValue" : false,
-                                  "isPure" : true,
-                                  "isStructConstructorCall" : false,
-                                  "lValueRequested" : false,
-                                  "names" : 
-                                  [
-                                    null
-                                  ],
-                                  "type" : "bytes32",
-                                  "type_conversion" : false
-                                },
-                                "children" : 
-                                [
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : 
-                                      [
-                                        {
-                                          "typeIdentifier" : "t_bytes_memory_ptr",
-                                          "typeString" : "bytes memory"
+                                           ],
+                                           "id":20,
+                                           "name":"Assignment",
+                                           "src":"282:30:0"
                                         }
-                                      ],
-                                      "overloadedDeclarations" : 
-                                      [
-                                        null
-                                      ],
-                                      "referencedDeclaration" : 125,
-                                      "type" : "function () pure returns (bytes32)",
-                                      "value" : "keccak256"
-                                    },
-                                    "id" : 94,
-                                    "name" : "Identifier",
-                                    "src" : "1028:9:0"
-                                  },
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : true,
-                                      "isStructConstructorCall" : false,
-                                      "lValueRequested" : false,
-                                      "names" : 
-                                      [
-                                        null
-                                      ],
-                                      "type" : "bytes memory",
-                                      "type_conversion" : false
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : 
-                                          [
-                                            {
-                                              "typeIdentifier" : "t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
-                                              "typeString" : "literal_string \"Nu Token\""
-                                            }
-                                          ],
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : true,
-                                          "lValueRequested" : false,
-                                          "member_name" : "encodePacked",
-                                          "referencedDeclaration" : null,
-                                          "type" : "function () pure returns (bytes memory)"
-                                        },
-                                        "children" : 
-                                        [
-                                          {
-                                            "attributes" : 
-                                            {
-                                              "argumentTypes" : null,
-                                              "overloadedDeclarations" : 
-                                              [
-                                                null
+                                     ],
+                                     "id":21,
+                                     "name":"ExpressionStatement",
+                                     "src":"282:30:0"
+                                  }
+                               ],
+                               "id":22,
+                               "name":"Block",
+                               "src":"276:41:0"
+                            }
+                         ],
+                         "id":23,
+                         "name":"FunctionDefinition",
+                         "src":"223:94:0"
+                      },
+                      {  
+                         "attributes":{  
+                            "documentation":null,
+                            "name":"supportsToken",
+                            "visibility":"internal"
+                         },
+                         "children":[  
+                            {  
+                               "attributes":{  
+                                  "parameters":[  
+                                     null
+                                  ]
+                               },
+                               "children":[  
+ 
+                               ],
+                               "id":24,
+                               "name":"ParameterList",
+                               "src":"397:2:0"
+                            },
+                            {  
+                               "children":[  
+                                  {  
+                                     "children":[  
+                                        {  
+                                           "attributes":{  
+                                              "argumentTypes":null,
+                                              "isConstant":false,
+                                              "isLValue":false,
+                                              "isPure":false,
+                                              "isStructConstructorCall":false,
+                                              "lValueRequested":false,
+                                              "names":[  
+                                                 null
                                               ],
-                                              "referencedDeclaration" : 118,
-                                              "type" : "abi",
-                                              "value" : "abi"
-                                            },
-                                            "id" : 95,
-                                            "name" : "Identifier",
-                                            "src" : "1038:3:0"
-                                          }
-                                        ],
-                                        "id" : 96,
-                                        "name" : "MemberAccess",
-                                        "src" : "1038:16:0"
-                                      },
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "hexvalue" : "4e7520546f6b656e",
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : true,
-                                          "lValueRequested" : false,
-                                          "subdenomination" : null,
-                                          "token" : "string",
-                                          "type" : "literal_string \"Nu Token\"",
-                                          "value" : "Nu Token"
-                                        },
-                                        "id" : 97,
-                                        "name" : "Literal",
-                                        "src" : "1055:10:0"
-                                      }
-                                    ],
-                                    "id" : 98,
-                                    "name" : "FunctionCall",
-                                    "src" : "1038:28:0"
+                                              "type":"tuple()",
+                                              "type_conversion":false
+                                           },
+                                           "children":[  
+                                              {  
+                                                 "attributes":{  
+                                                    "argumentTypes":[  
+                                                       {  
+                                                          "typeIdentifier":"t_bool",
+                                                          "typeString":"bool"
+                                                       }
+                                                    ],
+                                                    "overloadedDeclarations":[  
+                                                       90,
+                                                       91
+                                                    ],
+                                                    "referencedDeclaration":90,
+                                                    "type":"function (bool) pure",
+                                                    "value":"require"
+                                                 },
+                                                 "id":25,
+                                                 "name":"Identifier",
+                                                 "src":"406:7:0"
+                                              },
+                                              {  
+                                                 "attributes":{  
+                                                    "argumentTypes":null,
+                                                    "commonType":{  
+                                                       "typeIdentifier":"t_bytes32",
+                                                       "typeString":"bytes32"
+                                                    },
+                                                    "isConstant":false,
+                                                    "isLValue":false,
+                                                    "isPure":false,
+                                                    "lValueRequested":false,
+                                                    "operator":"==",
+                                                    "type":"bool"
+                                                 },
+                                                 "children":[  
+                                                    {  
+                                                       "attributes":{  
+                                                          "argumentTypes":null,
+                                                          "isConstant":false,
+                                                          "isLValue":false,
+                                                          "isPure":true,
+                                                          "isStructConstructorCall":false,
+                                                          "lValueRequested":false,
+                                                          "names":[  
+                                                             null
+                                                          ],
+                                                          "type":"bytes32",
+                                                          "type_conversion":false
+                                                       },
+                                                       "children":[  
+                                                          {  
+                                                             "attributes":{  
+                                                                "argumentTypes":[  
+                                                                   {  
+                                                                      "typeIdentifier":"t_bytes_memory_ptr",
+                                                                      "typeString":"bytes memory"
+                                                                   }
+                                                                ],
+                                                                "overloadedDeclarations":[  
+                                                                   null
+                                                                ],
+                                                                "referencedDeclaration":81,
+                                                                "type":"function (bytes memory) pure returns (bytes32)",
+                                                                "value":"keccak256"
+                                                             },
+                                                             "id":26,
+                                                             "name":"Identifier",
+                                                             "src":"414:9:0"
+                                                          },
+                                                          {  
+                                                             "attributes":{  
+                                                                "argumentTypes":null,
+                                                                "isConstant":false,
+                                                                "isLValue":false,
+                                                                "isPure":true,
+                                                                "isStructConstructorCall":false,
+                                                                "lValueRequested":false,
+                                                                "names":[  
+                                                                   null
+                                                                ],
+                                                                "type":"bytes memory",
+                                                                "type_conversion":false
+                                                             },
+                                                             "children":[  
+                                                                {  
+                                                                   "attributes":{  
+                                                                      "argumentTypes":[  
+                                                                         {  
+                                                                            "typeIdentifier":"t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
+                                                                            "typeString":"literal_string \"Nu Token\""
+                                                                         }
+                                                                      ],
+                                                                      "isConstant":false,
+                                                                      "isLValue":false,
+                                                                      "isPure":true,
+                                                                      "lValueRequested":false,
+                                                                      "member_name":"encodePacked",
+                                                                      "referencedDeclaration":null,
+                                                                      "type":"function () pure returns (bytes memory)"
+                                                                   },
+                                                                   "children":[  
+                                                                      {  
+                                                                         "attributes":{  
+                                                                            "argumentTypes":null,
+                                                                            "overloadedDeclarations":[  
+                                                                               null
+                                                                            ],
+                                                                            "referencedDeclaration":74,
+                                                                            "type":"abi",
+                                                                            "value":"abi"
+                                                                         },
+                                                                         "id":27,
+                                                                         "name":"Identifier",
+                                                                         "src":"424:3:0"
+                                                                      }
+                                                                   ],
+                                                                   "id":28,
+                                                                   "name":"MemberAccess",
+                                                                   "src":"424:16:0"
+                                                                },
+                                                                {  
+                                                                   "attributes":{  
+                                                                      "argumentTypes":null,
+                                                                      "hexvalue":"4e7520546f6b656e",
+                                                                      "isConstant":false,
+                                                                      "isLValue":false,
+                                                                      "isPure":true,
+                                                                      "lValueRequested":false,
+                                                                      "subdenomination":null,
+                                                                      "token":"string",
+                                                                      "type":"literal_string \"Nu Token\"",
+                                                                      "value":"Nu Token"
+                                                                   },
+                                                                   "id":29,
+                                                                   "name":"Literal",
+                                                                   "src":"441:10:0"
+                                                                }
+                                                             ],
+                                                             "id":30,
+                                                             "name":"FunctionCall",
+                                                             "src":"424:28:0"
+                                                          }
+                                                       ],
+                                                       "id":31,
+                                                       "name":"FunctionCall",
+                                                       "src":"414:39:0"
+                                                    },
+                                                    {  
+                                                       "attributes":{  
+                                                          "argumentTypes":null,
+                                                          "arguments":[  
+                                                             null
+                                                          ],
+                                                          "isConstant":false,
+                                                          "isLValue":false,
+                                                          "isPure":false,
+                                                          "isStructConstructorCall":false,
+                                                          "lValueRequested":false,
+                                                          "names":[  
+                                                             null
+                                                          ],
+                                                          "type":"bytes32",
+                                                          "type_conversion":false
+                                                       },
+                                                       "children":[  
+                                                          {  
+                                                             "attributes":{  
+                                                                "argumentTypes":[  
+                                                                   null
+                                                                ],
+                                                                "isConstant":false,
+                                                                "isLValue":false,
+                                                                "isPure":false,
+                                                                "lValueRequested":false,
+                                                                "member_name":"supportsToken",
+                                                                "referencedDeclaration":71,
+                                                                "type":"function () pure external returns (bytes32)"
+                                                             },
+                                                             "children":[  
+                                                                {  
+                                                                   "attributes":{  
+                                                                      "argumentTypes":null,
+                                                                      "isConstant":false,
+                                                                      "isLValue":false,
+                                                                      "isPure":false,
+                                                                      "isStructConstructorCall":false,
+                                                                      "lValueRequested":false,
+                                                                      "names":[  
+                                                                         null
+                                                                      ],
+                                                                      "type":"contract Bank",
+                                                                      "type_conversion":true
+                                                                   },
+                                                                   "children":[  
+                                                                      {  
+                                                                         "attributes":{  
+                                                                            "argumentTypes":[  
+                                                                               {  
+                                                                                  "typeIdentifier":"t_address_payable",
+                                                                                  "typeString":"address payable"
+                                                                               }
+                                                                            ],
+                                                                            "overloadedDeclarations":[  
+                                                                               null
+                                                                            ],
+                                                                            "referencedDeclaration":72,
+                                                                            "type":"type(contract Bank)",
+                                                                            "value":"Bank"
+                                                                         },
+                                                                         "id":32,
+                                                                         "name":"Identifier",
+                                                                         "src":"457:4:0"
+                                                                      },
+                                                                      {  
+                                                                         "attributes":{  
+                                                                            "argumentTypes":null,
+                                                                            "isConstant":false,
+                                                                            "isLValue":false,
+                                                                            "isPure":false,
+                                                                            "lValueRequested":false,
+                                                                            "member_name":"sender",
+                                                                            "referencedDeclaration":null,
+                                                                            "type":"address payable"
+                                                                         },
+                                                                         "children":[  
+                                                                            {  
+                                                                               "attributes":{  
+                                                                                  "argumentTypes":null,
+                                                                                  "overloadedDeclarations":[  
+                                                                                     null
+                                                                                  ],
+                                                                                  "referencedDeclaration":87,
+                                                                                  "type":"msg",
+                                                                                  "value":"msg"
+                                                                               },
+                                                                               "id":33,
+                                                                               "name":"Identifier",
+                                                                               "src":"462:3:0"
+                                                                            }
+                                                                         ],
+                                                                         "id":34,
+                                                                         "name":"MemberAccess",
+                                                                         "src":"462:10:0"
+                                                                      }
+                                                                   ],
+                                                                   "id":35,
+                                                                   "name":"FunctionCall",
+                                                                   "src":"457:16:0"
+                                                                }
+                                                             ],
+                                                             "id":36,
+                                                             "name":"MemberAccess",
+                                                             "src":"457:30:0"
+                                                          }
+                                                       ],
+                                                       "id":37,
+                                                       "name":"FunctionCall",
+                                                       "src":"457:32:0"
+                                                    }
+                                                 ],
+                                                 "id":38,
+                                                 "name":"BinaryOperation",
+                                                 "src":"414:75:0"
+                                              }
+                                           ],
+                                           "id":39,
+                                           "name":"FunctionCall",
+                                           "src":"406:84:0"
+                                        }
+                                     ],
+                                     "id":40,
+                                     "name":"ExpressionStatement",
+                                     "src":"406:84:0"
+                                  },
+                                  {  
+                                     "id":41,
+                                     "name":"PlaceholderStatement",
+                                     "src":"496:1:0"
                                   }
-                                ],
-                                "id" : 99,
-                                "name" : "FunctionCall",
-                                "src" : "1028:39:0"
-                              }
-                            ],
-                            "id" : 100,
-                            "name" : "TupleExpression",
-                            "src" : "1027:41:0"
-                          }
-                        ],
-                        "id" : 101,
-                        "name" : "Return",
-                        "src" : "1021:47:0"
+                               ],
+                               "id":42,
+                               "name":"Block",
+                               "src":"400:102:0"
+                            }
+                         ],
+                         "id":43,
+                         "name":"ModifierDefinition",
+                         "src":"375:127:0"
+                      },
+                      {  
+                         "attributes":{  
+                            "documentation":null,
+                            "name":"hasNoBalance",
+                            "visibility":"internal"
+                         },
+                         "children":[  
+                            {  
+                               "attributes":{  
+                                  "parameters":[  
+                                     null
+                                  ]
+                               },
+                               "children":[  
+ 
+                               ],
+                               "id":44,
+                               "name":"ParameterList",
+                               "src":"573:0:0"
+                            },
+                            {  
+                               "children":[  
+                                  {  
+                                     "children":[  
+                                        {  
+                                           "attributes":{  
+                                              "argumentTypes":null,
+                                              "isConstant":false,
+                                              "isLValue":false,
+                                              "isPure":false,
+                                              "isStructConstructorCall":false,
+                                              "lValueRequested":false,
+                                              "names":[  
+                                                 null
+                                              ],
+                                              "type":"tuple()",
+                                              "type_conversion":false
+                                           },
+                                           "children":[  
+                                              {  
+                                                 "attributes":{  
+                                                    "argumentTypes":[  
+                                                       {  
+                                                          "typeIdentifier":"t_bool",
+                                                          "typeString":"bool"
+                                                       }
+                                                    ],
+                                                    "overloadedDeclarations":[  
+                                                       90,
+                                                       91
+                                                    ],
+                                                    "referencedDeclaration":90,
+                                                    "type":"function (bool) pure",
+                                                    "value":"require"
+                                                 },
+                                                 "id":45,
+                                                 "name":"Identifier",
+                                                 "src":"581:7:0"
+                                              },
+                                              {  
+                                                 "attributes":{  
+                                                    "argumentTypes":null,
+                                                    "commonType":{  
+                                                       "typeIdentifier":"t_uint256",
+                                                       "typeString":"uint256"
+                                                    },
+                                                    "isConstant":false,
+                                                    "isLValue":false,
+                                                    "isPure":false,
+                                                    "lValueRequested":false,
+                                                    "operator":"==",
+                                                    "type":"bool"
+                                                 },
+                                                 "children":[  
+                                                    {  
+                                                       "attributes":{  
+                                                          "argumentTypes":null,
+                                                          "isConstant":false,
+                                                          "isLValue":true,
+                                                          "isPure":false,
+                                                          "lValueRequested":false,
+                                                          "type":"uint256"
+                                                       },
+                                                       "children":[  
+                                                          {  
+                                                             "attributes":{  
+                                                                "argumentTypes":null,
+                                                                "overloadedDeclarations":[  
+                                                                   null
+                                                                ],
+                                                                "referencedDeclaration":5,
+                                                                "type":"mapping(address => uint256)",
+                                                                "value":"tokenBalance"
+                                                             },
+                                                             "id":46,
+                                                             "name":"Identifier",
+                                                             "src":"589:12:0"
+                                                          },
+                                                          {  
+                                                             "attributes":{  
+                                                                "argumentTypes":null,
+                                                                "isConstant":false,
+                                                                "isLValue":false,
+                                                                "isPure":false,
+                                                                "lValueRequested":false,
+                                                                "member_name":"sender",
+                                                                "referencedDeclaration":null,
+                                                                "type":"address payable"
+                                                             },
+                                                             "children":[  
+                                                                {  
+                                                                   "attributes":{  
+                                                                      "argumentTypes":null,
+                                                                      "overloadedDeclarations":[  
+                                                                         null
+                                                                      ],
+                                                                      "referencedDeclaration":87,
+                                                                      "type":"msg",
+                                                                      "value":"msg"
+                                                                   },
+                                                                   "id":47,
+                                                                   "name":"Identifier",
+                                                                   "src":"602:3:0"
+                                                                }
+                                                             ],
+                                                             "id":48,
+                                                             "name":"MemberAccess",
+                                                             "src":"602:10:0"
+                                                          }
+                                                       ],
+                                                       "id":49,
+                                                       "name":"IndexAccess",
+                                                       "src":"589:24:0"
+                                                    },
+                                                    {  
+                                                       "attributes":{  
+                                                          "argumentTypes":null,
+                                                          "hexvalue":"30",
+                                                          "isConstant":false,
+                                                          "isLValue":false,
+                                                          "isPure":true,
+                                                          "lValueRequested":false,
+                                                          "subdenomination":null,
+                                                          "token":"number",
+                                                          "type":"int_const 0",
+                                                          "value":"0"
+                                                       },
+                                                       "id":50,
+                                                       "name":"Literal",
+                                                       "src":"617:1:0"
+                                                    }
+                                                 ],
+                                                 "id":51,
+                                                 "name":"BinaryOperation",
+                                                 "src":"589:29:0"
+                                              }
+                                           ],
+                                           "id":52,
+                                           "name":"FunctionCall",
+                                           "src":"581:38:0"
+                                        }
+                                     ],
+                                     "id":53,
+                                     "name":"ExpressionStatement",
+                                     "src":"581:38:0"
+                                  },
+                                  {  
+                                     "id":54,
+                                     "name":"PlaceholderStatement",
+                                     "src":"627:1:0"
+                                  }
+                               ],
+                               "id":55,
+                               "name":"Block",
+                               "src":"573:60:0"
+                            }
+                         ],
+                         "id":56,
+                         "name":"ModifierDefinition",
+                         "src":"551:82:0"
                       }
-                    ],
-                    "id" : 102,
-                    "name" : "Block",
-                    "src" : "887:188:0"
-                  }
-                ],
-                "id" : 103,
-                "name" : "FunctionDefinition",
-                "src" : "837:238:0"
-              },
-              {
-                "attributes" : 
-                {
-                  "constant" : false,
-                  "documentation" : null,
-                  "implemented" : true,
-                  "isConstructor" : false,
-                  "modifiers" : 
-                  [
-                    null
-                  ],
-                  "name" : "call",
-                  "payable" : false,
-                  "scope" : 116,
-                  "stateMutability" : "nonpayable",
-                  "superFunction" : null,
-                  "visibility" : "public"
+                   ],
+                   "id":57,
+                   "name":"ContractDefinition",
+                   "src":"25:610:0"
                 },
-                "children" : 
-                [
-                  {
-                    "children" : 
-                    [
-                      {
-                        "attributes" : 
-                        {
-                          "constant" : false,
-                          "name" : "token",
-                          "scope" : 115,
-                          "stateVariable" : false,
-                          "storageLocation" : "default",
-                          "type" : "address",
-                          "value" : null,
-                          "visibility" : "internal"
-                        },
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "name" : "address",
-                              "type" : "address"
-                            },
-                            "id" : 104,
-                            "name" : "ElementaryTypeName",
-                            "src" : "1094:7:0"
-                          }
-                        ],
-                        "id" : 105,
-                        "name" : "VariableDeclaration",
-                        "src" : "1094:13:0"
-                      }
-                    ],
-                    "id" : 106,
-                    "name" : "ParameterList",
-                    "src" : "1093:15:0"
-                  },
-                  {
-                    "attributes" : 
-                    {
-                      "parameters" : 
-                      [
-                        null
-                      ]
-                    },
-                    "children" : [],
-                    "id" : 107,
-                    "name" : "ParameterList",
-                    "src" : "1115:0:0"
-                  },
-                  {
-                    "children" : 
-                    [
-                      {
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "arguments" : 
-                              [
-                                null
-                              ],
-                              "isConstant" : false,
-                              "isLValue" : false,
-                              "isPure" : false,
-                              "isStructConstructorCall" : false,
-                              "lValueRequested" : false,
-                              "names" : 
-                              [
-                                null
-                              ],
-                              "type" : "tuple()",
-                              "type_conversion" : false
-                            },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : 
-                                  [
-                                    null
-                                  ],
-                                  "isConstant" : false,
-                                  "isLValue" : false,
-                                  "isPure" : false,
-                                  "lValueRequested" : false,
-                                  "member_name" : "airDrop",
-                                  "referencedDeclaration" : 23,
-                                  "type" : "function () external"
-                                },
-                                "children" : 
-                                [
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : false,
-                                      "isStructConstructorCall" : false,
-                                      "lValueRequested" : false,
-                                      "names" : 
-                                      [
-                                        null
-                                      ],
-                                      "type" : "contract ModifierEntrancy",
-                                      "type_conversion" : true
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : 
-                                          [
-                                            {
-                                              "typeIdentifier" : "t_address",
-                                              "typeString" : "address"
-                                            }
-                                          ],
-                                          "overloadedDeclarations" : 
-                                          [
-                                            null
-                                          ],
-                                          "referencedDeclaration" : 57,
-                                          "type" : "type(contract ModifierEntrancy)",
-                                          "value" : "ModifierEntrancy"
-                                        },
-                                        "id" : 108,
-                                        "name" : "Identifier",
-                                        "src" : "1125:16:0"
-                                      },
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "overloadedDeclarations" : 
-                                          [
-                                            null
-                                          ],
-                                          "referencedDeclaration" : 105,
-                                          "type" : "address",
-                                          "value" : "token"
-                                        },
-                                        "id" : 109,
-                                        "name" : "Identifier",
-                                        "src" : "1142:5:0"
-                                      }
-                                    ],
-                                    "id" : 110,
-                                    "name" : "FunctionCall",
-                                    "src" : "1125:23:0"
-                                  }
-                                ],
-                                "id" : 111,
-                                "name" : "MemberAccess",
-                                "src" : "1125:31:0"
-                              }
+                {  
+                   "attributes":{  
+                      "baseContracts":[  
+                         null
+                      ],
+                      "contractDependencies":[  
+                         null
+                      ],
+                      "contractKind":"contract",
+                      "documentation":null,
+                      "fullyImplemented":true,
+                      "linearizedBaseContracts":[  
+                         72
+                      ],
+                      "name":"Bank",
+                      "scope":73
+                   },
+                   "children":[  
+                      {  
+                         "attributes":{  
+                            "documentation":null,
+                            "implemented":true,
+                            "isConstructor":false,
+                            "kind":"function",
+                            "modifiers":[  
+                               null
                             ],
-                            "id" : 112,
-                            "name" : "FunctionCall",
-                            "src" : "1125:33:0"
-                          }
-                        ],
-                        "id" : 113,
-                        "name" : "ExpressionStatement",
-                        "src" : "1125:33:0"
+                            "name":"supportsToken",
+                            "scope":72,
+                            "stateMutability":"pure",
+                            "superFunction":null,
+                            "visibility":"external"
+                         },
+                         "children":[  
+                            {  
+                               "attributes":{  
+                                  "parameters":[  
+                                     null
+                                  ]
+                               },
+                               "children":[  
+ 
+                               ],
+                               "id":58,
+                               "name":"ParameterList",
+                               "src":"678:2:0"
+                            },
+                            {  
+                               "children":[  
+                                  {  
+                                     "attributes":{  
+                                        "constant":false,
+                                        "name":"",
+                                        "scope":71,
+                                        "stateVariable":false,
+                                        "storageLocation":"default",
+                                        "type":"bytes32",
+                                        "value":null,
+                                        "visibility":"internal"
+                                     },
+                                     "children":[  
+                                        {  
+                                           "attributes":{  
+                                              "name":"bytes32",
+                                              "type":"bytes32"
+                                           },
+                                           "id":59,
+                                           "name":"ElementaryTypeName",
+                                           "src":"703:7:0"
+                                        }
+                                     ],
+                                     "id":60,
+                                     "name":"VariableDeclaration",
+                                     "src":"703:7:0"
+                                  }
+                               ],
+                               "id":61,
+                               "name":"ParameterList",
+                               "src":"702:9:0"
+                            },
+                            {  
+                               "children":[  
+                                  {  
+                                     "attributes":{  
+                                        "functionReturnParameters":61
+                                     },
+                                     "children":[  
+                                        {  
+                                           "attributes":{  
+                                              "argumentTypes":null,
+                                              "isConstant":false,
+                                              "isInlineArray":false,
+                                              "isLValue":false,
+                                              "isPure":true,
+                                              "lValueRequested":false,
+                                              "type":"bytes32"
+                                           },
+                                           "children":[  
+                                              {  
+                                                 "attributes":{  
+                                                    "argumentTypes":null,
+                                                    "isConstant":false,
+                                                    "isLValue":false,
+                                                    "isPure":true,
+                                                    "isStructConstructorCall":false,
+                                                    "lValueRequested":false,
+                                                    "names":[  
+                                                       null
+                                                    ],
+                                                    "type":"bytes32",
+                                                    "type_conversion":false
+                                                 },
+                                                 "children":[  
+                                                    {  
+                                                       "attributes":{  
+                                                          "argumentTypes":[  
+                                                             {  
+                                                                "typeIdentifier":"t_bytes_memory_ptr",
+                                                                "typeString":"bytes memory"
+                                                             }
+                                                          ],
+                                                          "overloadedDeclarations":[  
+                                                             null
+                                                          ],
+                                                          "referencedDeclaration":81,
+                                                          "type":"function (bytes memory) pure returns (bytes32)",
+                                                          "value":"keccak256"
+                                                       },
+                                                       "id":62,
+                                                       "name":"Identifier",
+                                                       "src":"728:9:0"
+                                                    },
+                                                    {  
+                                                       "attributes":{  
+                                                          "argumentTypes":null,
+                                                          "isConstant":false,
+                                                          "isLValue":false,
+                                                          "isPure":true,
+                                                          "isStructConstructorCall":false,
+                                                          "lValueRequested":false,
+                                                          "names":[  
+                                                             null
+                                                          ],
+                                                          "type":"bytes memory",
+                                                          "type_conversion":false
+                                                       },
+                                                       "children":[  
+                                                          {  
+                                                             "attributes":{  
+                                                                "argumentTypes":[  
+                                                                   {  
+                                                                      "typeIdentifier":"t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
+                                                                      "typeString":"literal_string \"Nu Token\""
+                                                                   }
+                                                                ],
+                                                                "isConstant":false,
+                                                                "isLValue":false,
+                                                                "isPure":true,
+                                                                "lValueRequested":false,
+                                                                "member_name":"encodePacked",
+                                                                "referencedDeclaration":null,
+                                                                "type":"function () pure returns (bytes memory)"
+                                                             },
+                                                             "children":[  
+                                                                {  
+                                                                   "attributes":{  
+                                                                      "argumentTypes":null,
+                                                                      "overloadedDeclarations":[  
+                                                                         null
+                                                                      ],
+                                                                      "referencedDeclaration":74,
+                                                                      "type":"abi",
+                                                                      "value":"abi"
+                                                                   },
+                                                                   "id":63,
+                                                                   "name":"Identifier",
+                                                                   "src":"738:3:0"
+                                                                }
+                                                             ],
+                                                             "id":64,
+                                                             "name":"MemberAccess",
+                                                             "src":"738:16:0"
+                                                          },
+                                                          {  
+                                                             "attributes":{  
+                                                                "argumentTypes":null,
+                                                                "hexvalue":"4e7520546f6b656e",
+                                                                "isConstant":false,
+                                                                "isLValue":false,
+                                                                "isPure":true,
+                                                                "lValueRequested":false,
+                                                                "subdenomination":null,
+                                                                "token":"string",
+                                                                "type":"literal_string \"Nu Token\"",
+                                                                "value":"Nu Token"
+                                                             },
+                                                             "id":65,
+                                                             "name":"Literal",
+                                                             "src":"755:10:0"
+                                                          }
+                                                       ],
+                                                       "id":66,
+                                                       "name":"FunctionCall",
+                                                       "src":"738:28:0"
+                                                    }
+                                                 ],
+                                                 "id":67,
+                                                 "name":"FunctionCall",
+                                                 "src":"728:39:0"
+                                              }
+                                           ],
+                                           "id":68,
+                                           "name":"TupleExpression",
+                                           "src":"727:41:0"
+                                        }
+                                     ],
+                                     "id":69,
+                                     "name":"Return",
+                                     "src":"721:47:0"
+                                  }
+                               ],
+                               "id":70,
+                               "name":"Block",
+                               "src":"711:64:0"
+                            }
+                         ],
+                         "id":71,
+                         "name":"FunctionDefinition",
+                         "src":"656:119:0"
                       }
-                    ],
-                    "id" : 114,
-                    "name" : "Block",
-                    "src" : "1115:50:0"
-                  }
-                ],
-                "id" : 115,
-                "name" : "FunctionDefinition",
-                "src" : "1080:85:0"
-              }
-            ],
-            "id" : 116,
-            "name" : "ContractDefinition",
-            "src" : "792:375:0"
+                   ],
+                   "id":72,
+                   "name":"ContractDefinition",
+                   "src":"637:140:0"
+                }
+             ],
+             "id":73,
+             "name":"SourceUnit",
+             "src":"0:778:0"
           }
-        ],
-        "id" : 117,
-        "name" : "SourceUnit",
-        "src" : "0:1168:0"
-      }
-    }
-  },
-  "version" : "0.4.25+commit.59dbf8f1.Linux.g++"
-}
+       }
+    },
+    "version":"0.5.8+commit.23d335f2.Linux.g++"
+ }

--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract ModifierEntrancy {
   mapping (address => uint) public tokenBalance;
@@ -24,19 +24,5 @@ contract ModifierEntrancy {
 contract Bank{
     function supportsToken() external pure returns(bytes32){
         return(keccak256(abi.encodePacked("Nu Token")));
-    }
-}
-
-contract attack{ //An example of a contract that breaks the contract above.
-    bool hasBeenCalled;
-    function supportsToken() external returns(bytes32){
-        if(!hasBeenCalled){
-            hasBeenCalled = true;
-            ModifierEntrancy(msg.sender).airDrop();
-        }
-        return(keccak256(abi.encodePacked("Nu Token")));
-    }
-    function call(address token) public{
-        ModifierEntrancy(token).airDrop();
     }
 }


### PR DESCRIPTION
Removed `attack` contract which represents a way to attack contract in test case.