### PR TITLE
Update bytecode locations and line numbers in DOS samples

### DIFF
--- a/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
@@ -1,8 +1,9 @@
-description: DoS Gas Limit reaches when try to empty the array of addresses for winning the game
+description: DoS Gas Limit reached when trying to empty the array of addresses for winning the game
 issues:
 - id: SWC-128
   count: 1
   locations:
-  - bytecode_offsets: {}
+  - bytecode_offsets:
+      '0x757d6992eb9957af6d47433ed1efc2876156d0580cd2fbab68645c51dd919bcd': [408]
     line_numbers:
-      dos_address.sol: [10]
+      dos_address.sol: [9,10,11,12]

--- a/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
@@ -3,6 +3,7 @@ issues:
 - id: SWC-128
   count: 1
   locations:
-  - bytecode_offsets: {}
+  - bytecode_offsets:
+      '0x53aef779087c1829c3990fbf300aaafe4ccbd3328e8b6a630c7484b8c921aa8e': [408]
     line_numbers:
       dos_address.sol: [9,10,11,12]

--- a/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
@@ -6,4 +6,3 @@ issues:
   - bytecode_offsets: {}
     line_numbers:
       dos_address.sol: [9,10,11,12]
-  }

--- a/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
@@ -3,7 +3,7 @@ issues:
 - id: SWC-128
   count: 1
   locations:
-  - bytecode_offsets:
-      '0x757d6992eb9957af6d47433ed1efc2876156d0580cd2fbab68645c51dd919bcd': [408]
+  - bytecode_offsets: {}
     line_numbers:
       dos_address.sol: [9,10,11,12]
+  }

--- a/test_cases/solidity/dos_gas_limit/dos_number/dos_number.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_number/dos_number.yaml
@@ -1,11 +1,8 @@
 description: DoS Gas Limit in array empty and optionally in for loop
 issues:
 - id: SWC-128
-  count: 2
+  count: 1
   locations:
   - bytecode_offsets: {}
     line_numbers:
-      dos_number.sol: [11]
-  - bytecode_offsets: {}
-    line_numbers:
-      dos_number.sol: [29]
+      dos_number.sol: [11,12,13,14,15,16]

--- a/test_cases/solidity/dos_gas_limit/dos_number/dos_number.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_number/dos_number.yaml
@@ -3,6 +3,7 @@ issues:
 - id: SWC-128
   count: 1
   locations:
-  - bytecode_offsets: {}
+  - bytecode_offsets:
+      '0x3e71712b10e2878a71d36b38b239d8560bedb5a1e0e9b6ade8d61ce8ec28fdf1': [413]
     line_numbers:
       dos_number.sol: [11,12,13,14,15,16]

--- a/test_cases/solidity/dos_gas_limit/dos_simple/dos_simple.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_simple/dos_simple.yaml
@@ -3,6 +3,7 @@ issues:
 - id: SWC-128
   count: 1
   locations:
-  - bytecode_offsets: {}
+  - bytecode_offsets:
+      '0x81cafe753b96f7315b17b2bb5184b64b8f2cfe66a7077e94569355ce4dfa5208': [150]
     line_numbers:
       dos_simple.sol: [10,11,12]

--- a/test_cases/solidity/dos_gas_limit/dos_simple/dos_simple.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_simple/dos_simple.yaml
@@ -5,4 +5,4 @@ issues:
   locations:
   - bytecode_offsets: {}
     line_numbers:
-      dos_simple.sol: [16]
+      dos_simple.sol: [10,11,12]


### PR DESCRIPTION
Add bytecode offsets to the DOS sample configs and allow for a wider range of line numbers to be reported.