### PR TITLE
fix floating pragma description

### DIFF
--- a/test_cases/solidity/pragma_not_locked/floating_pragma_fixed/floating_pragma_fixed.yaml
+++ b/test_cases/solidity/pragma_not_locked/floating_pragma_fixed/floating_pragma_fixed.yaml
@@ -1,4 +1,4 @@
-description: Floating pragma fixed
+description: Floating pragma
 issues:
 - id: SWC-103
   count: 0


### PR DESCRIPTION
The description in .yaml file does not match the descriptions in floating_pragma.yaml and no_pragma.yaml. 