### PR TITLE
SWC-103 - add advanced samples with usage of semantic versioning operators supported by Solidity

### DIFF
--- a/test_cases/solidity/pragma_not_locked/semver_floating_pragma/semver_floating_pragma.json
+++ b/test_cases/solidity/pragma_not_locked/semver_floating_pragma/semver_floating_pragma.json
@@ -1,0 +1,295 @@
+{
+  "contracts" :
+  {
+    "semver_floating_pragma.sol:SemVerFloatingPragma" :
+    {
+      "bin" : "6080604052348015600f57600080fd5b50603580601d6000396000f3006080604052600080fd00a165627a7a72305820cc94a3673aa4f7054caa2aa6f1d7a455a0314193511c4bf8c471cff2afbc5cd70029",
+      "bin-runtime" : "6080604052600080fd00a165627a7a72305820cc94a3673aa4f7054caa2aa6f1d7a455a0314193511c4bf8c471cff2afbc5cd70029",
+      "srcmap" : "382:33:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;382:33:0;;;;;;;",
+      "srcmap-runtime" : "382:33:0:-;;;;;"
+    }
+  },
+  "sourceList" :
+  [
+    "semver_floating_pragma.sol"
+  ],
+  "sources" :
+  {
+    "semver_floating_pragma.sol" :
+    {
+      "AST" :
+      {
+        "attributes" :
+        {
+          "absolutePath" : "semver_floating_pragma.sol",
+          "exportedSymbols" :
+          {
+            "SemVerFloatingPragma" :
+            [
+              15
+            ]
+          }
+        },
+        "children" :
+        [
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                ">=",
+                "0.4",
+                ".0",
+                "<",
+                "0.6",
+                ".0"
+              ]
+            },
+            "id" : 1,
+            "name" : "PragmaDirective",
+            "src" : "0:32:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                ">=",
+                "0.4",
+                ".0",
+                "<",
+                "0.6",
+                ".0"
+              ]
+            },
+            "id" : 2,
+            "name" : "PragmaDirective",
+            "src" : "33:30:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                ">=",
+                "0.4",
+                ".14",
+                "<",
+                "0.6",
+                ".0"
+              ]
+            },
+            "id" : 3,
+            "name" : "PragmaDirective",
+            "src" : "64:32:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                ">",
+                "0.4",
+                ".13",
+                "<",
+                "0.6",
+                ".0"
+              ]
+            },
+            "id" : 4,
+            "name" : "PragmaDirective",
+            "src" : "97:31:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "0.4",
+                ".24",
+                "-",
+                "0.5",
+                ".2"
+              ]
+            },
+            "id" : 5,
+            "name" : "PragmaDirective",
+            "src" : "129:31:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                ">=",
+                "0.4",
+                ".24",
+                "<=",
+                "0.5",
+                ".3",
+                "~",
+                "0.4",
+                ".20"
+              ]
+            },
+            "id" : 6,
+            "name" : "PragmaDirective",
+            "src" : "161:41:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "<",
+                "0.4",
+                ".26"
+              ]
+            },
+            "id" : 7,
+            "name" : "PragmaDirective",
+            "src" : "203:24:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "~",
+                "0.4",
+                ".20"
+              ]
+            },
+            "id" : 8,
+            "name" : "PragmaDirective",
+            "src" : "228:24:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "^",
+                "0.4",
+                ".14"
+              ]
+            },
+            "id" : 9,
+            "name" : "PragmaDirective",
+            "src" : "253:24:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "0.4",
+                ".",
+                "*"
+              ]
+            },
+            "id" : 10,
+            "name" : "PragmaDirective",
+            "src" : "278:22:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "0.",
+                "*"
+              ]
+            },
+            "id" : 11,
+            "name" : "PragmaDirective",
+            "src" : "301:20:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "*"
+              ]
+            },
+            "id" : 12,
+            "name" : "PragmaDirective",
+            "src" : "322:18:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "0.4"
+              ]
+            },
+            "id" : 13,
+            "name" : "PragmaDirective",
+            "src" : "341:20:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "0"
+              ]
+            },
+            "id" : 14,
+            "name" : "PragmaDirective",
+            "src" : "362:18:0"
+          },
+          {
+            "attributes" :
+            {
+              "baseContracts" :
+              [
+                null
+              ],
+              "contractDependencies" :
+              [
+                null
+              ],
+              "contractKind" : "contract",
+              "documentation" : null,
+              "fullyImplemented" : true,
+              "linearizedBaseContracts" :
+              [
+                15
+              ],
+              "name" : "SemVerFloatingPragma",
+              "nodes" :
+              [
+                null
+              ],
+              "scope" : 16
+            },
+            "id" : 15,
+            "name" : "ContractDefinition",
+            "src" : "382:33:0"
+          }
+        ],
+        "id" : 16,
+        "name" : "SourceUnit",
+        "src" : "0:416:0"
+      }
+    }
+  },
+  "version" : "0.4.25+commit.59dbf8f1.Linux.g++"
+}

--- a/test_cases/solidity/pragma_not_locked/semver_floating_pragma/semver_floating_pragma.sol
+++ b/test_cases/solidity/pragma_not_locked/semver_floating_pragma/semver_floating_pragma.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.4.0 < 0.6.0;
+pragma solidity >=0.4.0<0.6.0;
+pragma solidity >=0.4.14 <0.6.0;
+pragma solidity >0.4.13 <0.6.0;
+pragma solidity 0.4.24 - 0.5.2;
+pragma solidity >=0.4.24 <=0.5.3 ~0.4.20;
+pragma solidity <0.4.26;
+pragma solidity ~0.4.20;
+pragma solidity ^0.4.14;
+pragma solidity 0.4.*;
+pragma solidity 0.*;
+pragma solidity *;
+pragma solidity 0.4;
+pragma solidity 0;
+
+contract SemVerFloatingPragma {
+}

--- a/test_cases/solidity/pragma_not_locked/semver_floating_pragma/semver_floating_pragma.yaml
+++ b/test_cases/solidity/pragma_not_locked/semver_floating_pragma/semver_floating_pragma.yaml
@@ -1,0 +1,47 @@
+description: Floating pragma with semantic versioning operators allows multiple compilers to be used
+issues:
+  - id: SWC-103
+    count: 14
+    locations:
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [1]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [2]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [3]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [4]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [5]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [6]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [7]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [8]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [9]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [10]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [11]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [12]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [13]
+      - bytecode_offsets: {}
+        line_numbers:
+          semver_floating_pragma.sol: [14]

--- a/test_cases/solidity/pragma_not_locked/semver_floating_pragma_fixed/semver_floating_pragma_fixed.json
+++ b/test_cases/solidity/pragma_not_locked/semver_floating_pragma_fixed/semver_floating_pragma_fixed.json
@@ -1,0 +1,101 @@
+{
+  "contracts" :
+  {
+    "semver_floating_pragma_fixed.sol:SemVerFloatingPragmaFixed" :
+    {
+      "bin" : "6080604052348015600f57600080fd5b50603580601d6000396000f3006080604052600080fd00a165627a7a72305820c9d69cd68b5d9e085e35c473bb2a5fae1f5b5b60e1337ed4d5da076787b67d6f0029",
+      "bin-runtime" : "6080604052600080fd00a165627a7a72305820c9d69cd68b5d9e085e35c473bb2a5fae1f5b5b60e1337ed4d5da076787b67d6f0029",
+      "srcmap" : "56:38:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;56:38:0;;;;;;;",
+      "srcmap-runtime" : "56:38:0:-;;;;;"
+    }
+  },
+  "sourceList" :
+  [
+    "semver_floating_pragma_fixed.sol"
+  ],
+  "sources" :
+  {
+    "semver_floating_pragma_fixed.sol" :
+    {
+      "AST" :
+      {
+        "attributes" :
+        {
+          "absolutePath" : "semver_floating_pragma_fixed.sol",
+          "exportedSymbols" :
+          {
+            "SemVerFloatingPragmaFixed" :
+            [
+              3
+            ]
+          }
+        },
+        "children" :
+        [
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "0.4",
+                ".25"
+              ]
+            },
+            "id" : 1,
+            "name" : "PragmaDirective",
+            "src" : "0:23:0"
+          },
+          {
+            "attributes" :
+            {
+              "literals" :
+              [
+                "solidity",
+                "=",
+                "0.4",
+                ".25"
+              ]
+            },
+            "id" : 2,
+            "name" : "PragmaDirective",
+            "src" : "30:24:0"
+          },
+          {
+            "attributes" :
+            {
+              "baseContracts" :
+              [
+                null
+              ],
+              "contractDependencies" :
+              [
+                null
+              ],
+              "contractKind" : "contract",
+              "documentation" : null,
+              "fullyImplemented" : true,
+              "linearizedBaseContracts" :
+              [
+                3
+              ],
+              "name" : "SemVerFloatingPragmaFixed",
+              "nodes" :
+              [
+                null
+              ],
+              "scope" : 4
+            },
+            "id" : 3,
+            "name" : "ContractDefinition",
+            "src" : "56:38:0"
+          }
+        ],
+        "id" : 4,
+        "name" : "SourceUnit",
+        "src" : "0:95:0"
+      }
+    }
+  },
+  "version" : "0.4.25+commit.59dbf8f1.Linux.g++"
+}

--- a/test_cases/solidity/pragma_not_locked/semver_floating_pragma_fixed/semver_floating_pragma_fixed.sol
+++ b/test_cases/solidity/pragma_not_locked/semver_floating_pragma_fixed/semver_floating_pragma_fixed.sol
@@ -1,0 +1,6 @@
+pragma solidity 0.4.25;
+// or
+pragma solidity =0.4.25;
+
+contract SemVerFloatingPragmaFixed {
+}

--- a/test_cases/solidity/pragma_not_locked/semver_floating_pragma_fixed/semver_floating_pragma_fixed.yaml
+++ b/test_cases/solidity/pragma_not_locked/semver_floating_pragma_fixed/semver_floating_pragma_fixed.yaml
@@ -1,0 +1,5 @@
+description: Floating pragma with semantic versioning operators allows multiple compilers to be used
+issues:
+  - id: SWC-103
+    count: 0
+    locations: []


### PR DESCRIPTION
## Brief
This proposal suggests to include more complicated examples with usage of [SemVer operators](https://devhints.io/semver), which are supported by Solidity.

## Changes
- Introduced `semver_floating_pragma` sample with extended `pragma solidity` values, like:
```
pragma solidity >=0.4.0 < 0.6.0;
pragma solidity >=0.4.0<0.6.0;
pragma solidity >=0.4.14 <0.6.0;
pragma solidity >0.4.13 <0.6.0;
pragma solidity 0.4.24 - 0.5.2;
pragma solidity >=0.4.24 <=0.5.3 ~0.4.20;
pragma solidity <0.4.26;
pragma solidity ~0.4.20;
pragma solidity ^0.4.14;
pragma solidity 0.4.*;
pragma solidity 0.*;
pragma solidity *;
pragma solidity 0.4;
pragma solidity 0;
```
- Introduced `semver_floating_pragma_fixed` sample with allowed fixes, that locks compiler version.
```
pragma solidity 0.4.25;
// or
pragma solidity =0.4.25;
```

Regards, @blitz-1306.