### PR TITLE
Tweak location info for SWC-128

### DIFF
--- a/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_address/dos_address.yaml
@@ -6,4 +6,4 @@ issues:
   - bytecode_offsets:
       '0x53aef779087c1829c3990fbf300aaafe4ccbd3328e8b6a630c7484b8c921aa8e': [408]
     line_numbers:
-      dos_address.sol: [9,10,11,12]
+      dos_address.sol: [10]

--- a/test_cases/solidity/dos_gas_limit/dos_number/dos_number.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_number/dos_number.yaml
@@ -3,7 +3,6 @@ issues:
 - id: SWC-128
   count: 1
   locations:
-  - bytecode_offsets:
-      '0x3e71712b10e2878a71d36b38b239d8560bedb5a1e0e9b6ade8d61ce8ec28fdf1': [413]
+  - bytecode_offsets: {}
     line_numbers:
       dos_number.sol: [29]

--- a/test_cases/solidity/dos_gas_limit/dos_number/dos_number.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_number/dos_number.yaml
@@ -6,4 +6,4 @@ issues:
   - bytecode_offsets:
       '0x3e71712b10e2878a71d36b38b239d8560bedb5a1e0e9b6ade8d61ce8ec28fdf1': [413]
     line_numbers:
-      dos_number.sol: [11,12,13,14,15,16]
+      dos_number.sol: [29]

--- a/test_cases/solidity/dos_gas_limit/dos_simple/dos_simple.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_simple/dos_simple.yaml
@@ -3,6 +3,6 @@ issues:
 - id: SWC-128
   count: 1
   locations:
-  - bytecode_offsets:
+  - bytecode_offsets: {}
     line_numbers:
       dos_simple.sol: [16]

--- a/test_cases/solidity/dos_gas_limit/dos_simple/dos_simple.yaml
+++ b/test_cases/solidity/dos_gas_limit/dos_simple/dos_simple.yaml
@@ -4,6 +4,5 @@ issues:
   count: 1
   locations:
   - bytecode_offsets:
-      '0x81cafe753b96f7315b17b2bb5184b64b8f2cfe66a7077e94569355ce4dfa5208': [150]
     line_numbers:
-      dos_simple.sol: [10,11,12]
+      dos_simple.sol: [16]


### PR DESCRIPTION
In SWC-128 a data structure may grow very large over a series of _successful_ transactions to a point where some function that iterates over that data structure requires too much gas, causing a DoS. There are 2 general places where you can fix this issue:

1) Prevent the datastructure from growing unboundedly

2) Re-write all functions that iterate over the data structure to be able to do so over multiple transactions. 

The text of SWC-128, and especially the remediation parts focus on (2). E.g.

"Caution is advised when you expect to have large arrays that grow over time. Actions that require looping across the entire data structure should be avoided.

If you absolutely must loop over an array of unknown size, then you should plan for it to potentially take multiple blocks, and therefore require multiple transactions."

2 of the 3 examples however(dos_number.sol and dos_simple.sol) point out the location where the data structure grows instead of the location that iterates and causes the DoS.

This PR proposes to change the location of these two samples.

Note: A more complete solution would be to report both locations as contributing to the issue, however doing this cleanly requires support for multiple tagged locations associated with a single issue. After this has been implemented we can expand the source location for these issues.