### PR TITLE
Change modifier_reentrancy example to adjust for static calls

### DIFF
--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.json
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.json
@@ -1,1108 +1,1348 @@
-{  
-    "contracts":{  
-        "modifier_reentrancy.sol:ModifierEntrancy":{  
-           "bin":"608060405234801561001057600080fd5b5061024d806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610209565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b815260040160206040518083038186803b15801561012e57600080fd5b505afa158015610142573d6000803e3d6000fd5b505050506040513d602081101561015857600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101ba57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208dd98a51ad2b4cf491fd15e78829d1f68269e6efc7954dce772a2daaa09b129d0029",
-           "bin-runtime":"608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610209565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b815260040160206040518083038186803b15801561012e57600080fd5b505afa158015610142573d6000803e3d6000fd5b505050506040513d602081101561015857600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101ba57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208dd98a51ad2b4cf491fd15e78829d1f68269e6efc7954dce772a2daaa09b129d0029",
-           "srcmap":"25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;",
-           "srcmap-runtime":"25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;;;;;;;;;;;;;;;;;;223:94;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;223:94;617:1;589:12;:24;602:10;589:24;;;;;;;;;;;;;;;;:29;581:38;;;;;;462:10;457:30;;;:32;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;457:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;457:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;457:32:0;;;;;;;;;;;;;;;;424:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;424:28:0;;;414:39;;;;;;:75;406:84;;;;;;310:2;282:12;:24;295:10;282:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;223:94::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
-        },
-       "modifier_reentrancy.sol:Bank":{  
-          "bin":"6080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820604ef1ba30e51d37bd823bee7847bd79f487b494fa566450adf2888bda45eb6d0029",
-          "bin-runtime":"6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820604ef1ba30e51d37bd823bee7847bd79f487b494fa566450adf2888bda45eb6d0029",
-          "srcmap":"637:140:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:140:0;;;;;;;",
-          "srcmap-runtime":"637:140:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:140:0;;;;;;;;;;;;;;;;;;;656:119;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;703:7;738:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;738:28:0;;;728:39;;;;;;721:47;;656:119;:::o"
-       }
+{
+  "contracts" : 
+  {
+    "modifier_reentrancy/modifier_reentrancy.sol:Bank" : 
+    {
+      "bin" : "6080604052348015600f57600080fd5b5060cb8061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000600160008190555060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820658c89e74be7111844c6e94d7cc01210ea45199e112a867038b8981a731010990029",
+      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000600160008190555060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820658c89e74be7111844c6e94d7cc01210ea45199e112a867038b8981a731010990029",
+      "srcmap" : "637:178:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:178:0;;;;;;;",
+      "srcmap-runtime" : "637:178:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:178:0;;;;;;;;;;;;;;;;;;;676:137;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;718:7;748:1;736:9;:13;;;;776:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;776:28:0;;;766:39;;;;;;759:47;;676:137;:::o"
     },
-    "sourceList":[  
-       "modifier_reentrancy.sol"
-    ],
-    "sources":{  
-       "modifier_reentrancy.sol":{  
-          "AST":{  
-             "attributes":{  
-                "absolutePath":"modifier_reentrancy.sol",
-                "exportedSymbols":{  
-                   "Bank":[  
-                      72
-                   ],
-                   "ModifierEntrancy":[  
-                      57
-                   ]
-                }
-             },
-             "children":[  
-                {  
-                   "attributes":{  
-                      "literals":[  
-                         "solidity",
-                         "^",
-                         "0.5",
-                         ".0"
-                      ]
-                   },
-                   "id":1,
-                   "name":"PragmaDirective",
-                   "src":"0:23:0"
-                },
-                {  
-                   "attributes":{  
-                      "baseContracts":[  
-                         null
-                      ],
-                      "contractDependencies":[  
-                         null
-                      ],
-                      "contractKind":"contract",
-                      "documentation":null,
-                      "fullyImplemented":true,
-                      "linearizedBaseContracts":[  
-                         57
-                      ],
-                      "name":"ModifierEntrancy",
-                      "scope":73
-                   },
-                   "children":[  
-                      {  
-                         "attributes":{  
-                            "constant":false,
-                            "name":"tokenBalance",
-                            "scope":57,
-                            "stateVariable":true,
-                            "storageLocation":"default",
-                            "type":"mapping(address => uint256)",
-                            "value":null,
-                            "visibility":"public"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "type":"mapping(address => uint256)"
-                               },
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "name":"address",
-                                        "type":"address"
-                                     },
-                                     "id":2,
-                                     "name":"ElementaryTypeName",
-                                     "src":"64:7:0"
-                                  },
-                                  {  
-                                     "attributes":{  
-                                        "name":"uint",
-                                        "type":"uint256"
-                                     },
-                                     "id":3,
-                                     "name":"ElementaryTypeName",
-                                     "src":"75:4:0"
-                                  }
-                               ],
-                               "id":4,
-                               "name":"Mapping",
-                               "src":"55:25:0"
-                            }
-                         ],
-                         "id":5,
-                         "name":"VariableDeclaration",
-                         "src":"55:45:0"
-                      },
-                      {  
-                         "attributes":{  
-                            "constant":true,
-                            "name":"name",
-                            "scope":57,
-                            "stateVariable":true,
-                            "storageLocation":"default",
-                            "type":"string",
-                            "visibility":"internal"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "name":"string",
-                                  "type":"string"
-                               },
-                               "id":6,
-                               "name":"ElementaryTypeName",
-                               "src":"104:6:0"
-                            },
-                            {  
-                               "attributes":{  
-                                  "argumentTypes":null,
-                                  "hexvalue":"4e7520546f6b656e",
-                                  "isConstant":false,
-                                  "isLValue":false,
-                                  "isPure":true,
-                                  "lValueRequested":false,
-                                  "subdenomination":null,
-                                  "token":"string",
-                                  "type":"literal_string \"Nu Token\"",
-                                  "value":"Nu Token"
-                               },
-                               "id":7,
-                               "name":"Literal",
-                               "src":"127:10:0"
-                            }
-                         ],
-                         "id":8,
-                         "name":"VariableDeclaration",
-                         "src":"104:33:0"
-                      },
-                      {  
-                         "attributes":{  
-                            "documentation":null,
-                            "implemented":true,
-                            "isConstructor":false,
-                            "kind":"function",
-                            "name":"airDrop",
-                            "scope":57,
-                            "stateMutability":"nonpayable",
-                            "superFunction":null,
-                            "visibility":"public"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":9,
-                               "name":"ParameterList",
-                               "src":"239:2:0"
-                            },
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":14,
-                               "name":"ParameterList",
-                               "src":"276:0:0"
-                            },
-                            {  
-                               "attributes":{  
-                                  "arguments":null
-                               },
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "argumentTypes":null,
-                                        "overloadedDeclarations":[  
-                                           null
-                                        ],
-                                        "referencedDeclaration":56,
-                                        "type":"modifier ()",
-                                        "value":"hasNoBalance"
-                                     },
-                                     "id":10,
-                                     "name":"Identifier",
-                                     "src":"242:12:0"
-                                  }
-                               ],
-                               "id":11,
-                               "name":"ModifierInvocation",
-                               "src":"242:12:0"
-                            },
-                            {  
-                               "attributes":{  
-                                  "arguments":null
-                               },
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "argumentTypes":null,
-                                        "overloadedDeclarations":[  
-                                           null
-                                        ],
-                                        "referencedDeclaration":43,
-                                        "type":"modifier ()",
-                                        "value":"supportsToken"
-                                     },
-                                     "id":12,
-                                     "name":"Identifier",
-                                     "src":"255:13:0"
-                                  }
-                               ],
-                               "id":13,
-                               "name":"ModifierInvocation",
-                               "src":"255:13:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "argumentTypes":null,
-                                              "isConstant":false,
-                                              "isLValue":false,
-                                              "isPure":false,
-                                              "lValueRequested":false,
-                                              "operator":"+=",
-                                              "type":"uint256"
-                                           },
-                                           "children":[  
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "isConstant":false,
-                                                    "isLValue":true,
-                                                    "isPure":false,
-                                                    "lValueRequested":true,
-                                                    "type":"uint256"
-                                                 },
-                                                 "children":[  
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "overloadedDeclarations":[  
-                                                             null
-                                                          ],
-                                                          "referencedDeclaration":5,
-                                                          "type":"mapping(address => uint256)",
-                                                          "value":"tokenBalance"
-                                                       },
-                                                       "id":15,
-                                                       "name":"Identifier",
-                                                       "src":"282:12:0"
-                                                    },
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":false,
-                                                          "lValueRequested":false,
-                                                          "member_name":"sender",
-                                                          "referencedDeclaration":null,
-                                                          "type":"address payable"
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "overloadedDeclarations":[  
-                                                                   null
-                                                                ],
-                                                                "referencedDeclaration":87,
-                                                                "type":"msg",
-                                                                "value":"msg"
-                                                             },
-                                                             "id":16,
-                                                             "name":"Identifier",
-                                                             "src":"295:3:0"
-                                                          }
-                                                       ],
-                                                       "id":17,
-                                                       "name":"MemberAccess",
-                                                       "src":"295:10:0"
-                                                    }
-                                                 ],
-                                                 "id":18,
-                                                 "name":"IndexAccess",
-                                                 "src":"282:24:0"
-                                              },
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "hexvalue":"3230",
-                                                    "isConstant":false,
-                                                    "isLValue":false,
-                                                    "isPure":true,
-                                                    "lValueRequested":false,
-                                                    "subdenomination":null,
-                                                    "token":"number",
-                                                    "type":"int_const 20",
-                                                    "value":"20"
-                                                 },
-                                                 "id":19,
-                                                 "name":"Literal",
-                                                 "src":"310:2:0"
-                                              }
-                                           ],
-                                           "id":20,
-                                           "name":"Assignment",
-                                           "src":"282:30:0"
-                                        }
-                                     ],
-                                     "id":21,
-                                     "name":"ExpressionStatement",
-                                     "src":"282:30:0"
-                                  }
-                               ],
-                               "id":22,
-                               "name":"Block",
-                               "src":"276:41:0"
-                            }
-                         ],
-                         "id":23,
-                         "name":"FunctionDefinition",
-                         "src":"223:94:0"
-                      },
-                      {  
-                         "attributes":{  
-                            "documentation":null,
-                            "name":"supportsToken",
-                            "visibility":"internal"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":24,
-                               "name":"ParameterList",
-                               "src":"397:2:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "argumentTypes":null,
-                                              "isConstant":false,
-                                              "isLValue":false,
-                                              "isPure":false,
-                                              "isStructConstructorCall":false,
-                                              "lValueRequested":false,
-                                              "names":[  
-                                                 null
-                                              ],
-                                              "type":"tuple()",
-                                              "type_conversion":false
-                                           },
-                                           "children":[  
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":[  
-                                                       {  
-                                                          "typeIdentifier":"t_bool",
-                                                          "typeString":"bool"
-                                                       }
-                                                    ],
-                                                    "overloadedDeclarations":[  
-                                                       90,
-                                                       91
-                                                    ],
-                                                    "referencedDeclaration":90,
-                                                    "type":"function (bool) pure",
-                                                    "value":"require"
-                                                 },
-                                                 "id":25,
-                                                 "name":"Identifier",
-                                                 "src":"406:7:0"
-                                              },
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "commonType":{  
-                                                       "typeIdentifier":"t_bytes32",
-                                                       "typeString":"bytes32"
-                                                    },
-                                                    "isConstant":false,
-                                                    "isLValue":false,
-                                                    "isPure":false,
-                                                    "lValueRequested":false,
-                                                    "operator":"==",
-                                                    "type":"bool"
-                                                 },
-                                                 "children":[  
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":true,
-                                                          "isStructConstructorCall":false,
-                                                          "lValueRequested":false,
-                                                          "names":[  
-                                                             null
-                                                          ],
-                                                          "type":"bytes32",
-                                                          "type_conversion":false
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":[  
-                                                                   {  
-                                                                      "typeIdentifier":"t_bytes_memory_ptr",
-                                                                      "typeString":"bytes memory"
-                                                                   }
-                                                                ],
-                                                                "overloadedDeclarations":[  
-                                                                   null
-                                                                ],
-                                                                "referencedDeclaration":81,
-                                                                "type":"function (bytes memory) pure returns (bytes32)",
-                                                                "value":"keccak256"
-                                                             },
-                                                             "id":26,
-                                                             "name":"Identifier",
-                                                             "src":"414:9:0"
-                                                          },
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":true,
-                                                                "isStructConstructorCall":false,
-                                                                "lValueRequested":false,
-                                                                "names":[  
-                                                                   null
-                                                                ],
-                                                                "type":"bytes memory",
-                                                                "type_conversion":false
-                                                             },
-                                                             "children":[  
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":[  
-                                                                         {  
-                                                                            "typeIdentifier":"t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
-                                                                            "typeString":"literal_string \"Nu Token\""
-                                                                         }
-                                                                      ],
-                                                                      "isConstant":false,
-                                                                      "isLValue":false,
-                                                                      "isPure":true,
-                                                                      "lValueRequested":false,
-                                                                      "member_name":"encodePacked",
-                                                                      "referencedDeclaration":null,
-                                                                      "type":"function () pure returns (bytes memory)"
-                                                                   },
-                                                                   "children":[  
-                                                                      {  
-                                                                         "attributes":{  
-                                                                            "argumentTypes":null,
-                                                                            "overloadedDeclarations":[  
-                                                                               null
-                                                                            ],
-                                                                            "referencedDeclaration":74,
-                                                                            "type":"abi",
-                                                                            "value":"abi"
-                                                                         },
-                                                                         "id":27,
-                                                                         "name":"Identifier",
-                                                                         "src":"424:3:0"
-                                                                      }
-                                                                   ],
-                                                                   "id":28,
-                                                                   "name":"MemberAccess",
-                                                                   "src":"424:16:0"
-                                                                },
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":null,
-                                                                      "hexvalue":"4e7520546f6b656e",
-                                                                      "isConstant":false,
-                                                                      "isLValue":false,
-                                                                      "isPure":true,
-                                                                      "lValueRequested":false,
-                                                                      "subdenomination":null,
-                                                                      "token":"string",
-                                                                      "type":"literal_string \"Nu Token\"",
-                                                                      "value":"Nu Token"
-                                                                   },
-                                                                   "id":29,
-                                                                   "name":"Literal",
-                                                                   "src":"441:10:0"
-                                                                }
-                                                             ],
-                                                             "id":30,
-                                                             "name":"FunctionCall",
-                                                             "src":"424:28:0"
-                                                          }
-                                                       ],
-                                                       "id":31,
-                                                       "name":"FunctionCall",
-                                                       "src":"414:39:0"
-                                                    },
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "arguments":[  
-                                                             null
-                                                          ],
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":false,
-                                                          "isStructConstructorCall":false,
-                                                          "lValueRequested":false,
-                                                          "names":[  
-                                                             null
-                                                          ],
-                                                          "type":"bytes32",
-                                                          "type_conversion":false
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":[  
-                                                                   null
-                                                                ],
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":false,
-                                                                "lValueRequested":false,
-                                                                "member_name":"supportsToken",
-                                                                "referencedDeclaration":71,
-                                                                "type":"function () pure external returns (bytes32)"
-                                                             },
-                                                             "children":[  
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":null,
-                                                                      "isConstant":false,
-                                                                      "isLValue":false,
-                                                                      "isPure":false,
-                                                                      "isStructConstructorCall":false,
-                                                                      "lValueRequested":false,
-                                                                      "names":[  
-                                                                         null
-                                                                      ],
-                                                                      "type":"contract Bank",
-                                                                      "type_conversion":true
-                                                                   },
-                                                                   "children":[  
-                                                                      {  
-                                                                         "attributes":{  
-                                                                            "argumentTypes":[  
-                                                                               {  
-                                                                                  "typeIdentifier":"t_address_payable",
-                                                                                  "typeString":"address payable"
-                                                                               }
-                                                                            ],
-                                                                            "overloadedDeclarations":[  
-                                                                               null
-                                                                            ],
-                                                                            "referencedDeclaration":72,
-                                                                            "type":"type(contract Bank)",
-                                                                            "value":"Bank"
-                                                                         },
-                                                                         "id":32,
-                                                                         "name":"Identifier",
-                                                                         "src":"457:4:0"
-                                                                      },
-                                                                      {  
-                                                                         "attributes":{  
-                                                                            "argumentTypes":null,
-                                                                            "isConstant":false,
-                                                                            "isLValue":false,
-                                                                            "isPure":false,
-                                                                            "lValueRequested":false,
-                                                                            "member_name":"sender",
-                                                                            "referencedDeclaration":null,
-                                                                            "type":"address payable"
-                                                                         },
-                                                                         "children":[  
-                                                                            {  
-                                                                               "attributes":{  
-                                                                                  "argumentTypes":null,
-                                                                                  "overloadedDeclarations":[  
-                                                                                     null
-                                                                                  ],
-                                                                                  "referencedDeclaration":87,
-                                                                                  "type":"msg",
-                                                                                  "value":"msg"
-                                                                               },
-                                                                               "id":33,
-                                                                               "name":"Identifier",
-                                                                               "src":"462:3:0"
-                                                                            }
-                                                                         ],
-                                                                         "id":34,
-                                                                         "name":"MemberAccess",
-                                                                         "src":"462:10:0"
-                                                                      }
-                                                                   ],
-                                                                   "id":35,
-                                                                   "name":"FunctionCall",
-                                                                   "src":"457:16:0"
-                                                                }
-                                                             ],
-                                                             "id":36,
-                                                             "name":"MemberAccess",
-                                                             "src":"457:30:0"
-                                                          }
-                                                       ],
-                                                       "id":37,
-                                                       "name":"FunctionCall",
-                                                       "src":"457:32:0"
-                                                    }
-                                                 ],
-                                                 "id":38,
-                                                 "name":"BinaryOperation",
-                                                 "src":"414:75:0"
-                                              }
-                                           ],
-                                           "id":39,
-                                           "name":"FunctionCall",
-                                           "src":"406:84:0"
-                                        }
-                                     ],
-                                     "id":40,
-                                     "name":"ExpressionStatement",
-                                     "src":"406:84:0"
-                                  },
-                                  {  
-                                     "id":41,
-                                     "name":"PlaceholderStatement",
-                                     "src":"496:1:0"
-                                  }
-                               ],
-                               "id":42,
-                               "name":"Block",
-                               "src":"400:102:0"
-                            }
-                         ],
-                         "id":43,
-                         "name":"ModifierDefinition",
-                         "src":"375:127:0"
-                      },
-                      {  
-                         "attributes":{  
-                            "documentation":null,
-                            "name":"hasNoBalance",
-                            "visibility":"internal"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":44,
-                               "name":"ParameterList",
-                               "src":"573:0:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "argumentTypes":null,
-                                              "isConstant":false,
-                                              "isLValue":false,
-                                              "isPure":false,
-                                              "isStructConstructorCall":false,
-                                              "lValueRequested":false,
-                                              "names":[  
-                                                 null
-                                              ],
-                                              "type":"tuple()",
-                                              "type_conversion":false
-                                           },
-                                           "children":[  
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":[  
-                                                       {  
-                                                          "typeIdentifier":"t_bool",
-                                                          "typeString":"bool"
-                                                       }
-                                                    ],
-                                                    "overloadedDeclarations":[  
-                                                       90,
-                                                       91
-                                                    ],
-                                                    "referencedDeclaration":90,
-                                                    "type":"function (bool) pure",
-                                                    "value":"require"
-                                                 },
-                                                 "id":45,
-                                                 "name":"Identifier",
-                                                 "src":"581:7:0"
-                                              },
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "commonType":{  
-                                                       "typeIdentifier":"t_uint256",
-                                                       "typeString":"uint256"
-                                                    },
-                                                    "isConstant":false,
-                                                    "isLValue":false,
-                                                    "isPure":false,
-                                                    "lValueRequested":false,
-                                                    "operator":"==",
-                                                    "type":"bool"
-                                                 },
-                                                 "children":[  
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "isConstant":false,
-                                                          "isLValue":true,
-                                                          "isPure":false,
-                                                          "lValueRequested":false,
-                                                          "type":"uint256"
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "overloadedDeclarations":[  
-                                                                   null
-                                                                ],
-                                                                "referencedDeclaration":5,
-                                                                "type":"mapping(address => uint256)",
-                                                                "value":"tokenBalance"
-                                                             },
-                                                             "id":46,
-                                                             "name":"Identifier",
-                                                             "src":"589:12:0"
-                                                          },
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":false,
-                                                                "lValueRequested":false,
-                                                                "member_name":"sender",
-                                                                "referencedDeclaration":null,
-                                                                "type":"address payable"
-                                                             },
-                                                             "children":[  
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":null,
-                                                                      "overloadedDeclarations":[  
-                                                                         null
-                                                                      ],
-                                                                      "referencedDeclaration":87,
-                                                                      "type":"msg",
-                                                                      "value":"msg"
-                                                                   },
-                                                                   "id":47,
-                                                                   "name":"Identifier",
-                                                                   "src":"602:3:0"
-                                                                }
-                                                             ],
-                                                             "id":48,
-                                                             "name":"MemberAccess",
-                                                             "src":"602:10:0"
-                                                          }
-                                                       ],
-                                                       "id":49,
-                                                       "name":"IndexAccess",
-                                                       "src":"589:24:0"
-                                                    },
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "hexvalue":"30",
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":true,
-                                                          "lValueRequested":false,
-                                                          "subdenomination":null,
-                                                          "token":"number",
-                                                          "type":"int_const 0",
-                                                          "value":"0"
-                                                       },
-                                                       "id":50,
-                                                       "name":"Literal",
-                                                       "src":"617:1:0"
-                                                    }
-                                                 ],
-                                                 "id":51,
-                                                 "name":"BinaryOperation",
-                                                 "src":"589:29:0"
-                                              }
-                                           ],
-                                           "id":52,
-                                           "name":"FunctionCall",
-                                           "src":"581:38:0"
-                                        }
-                                     ],
-                                     "id":53,
-                                     "name":"ExpressionStatement",
-                                     "src":"581:38:0"
-                                  },
-                                  {  
-                                     "id":54,
-                                     "name":"PlaceholderStatement",
-                                     "src":"627:1:0"
-                                  }
-                               ],
-                               "id":55,
-                               "name":"Block",
-                               "src":"573:60:0"
-                            }
-                         ],
-                         "id":56,
-                         "name":"ModifierDefinition",
-                         "src":"551:82:0"
-                      }
-                   ],
-                   "id":57,
-                   "name":"ContractDefinition",
-                   "src":"25:610:0"
-                },
-                {  
-                   "attributes":{  
-                      "baseContracts":[  
-                         null
-                      ],
-                      "contractDependencies":[  
-                         null
-                      ],
-                      "contractKind":"contract",
-                      "documentation":null,
-                      "fullyImplemented":true,
-                      "linearizedBaseContracts":[  
-                         72
-                      ],
-                      "name":"Bank",
-                      "scope":73
-                   },
-                   "children":[  
-                      {  
-                         "attributes":{  
-                            "documentation":null,
-                            "implemented":true,
-                            "isConstructor":false,
-                            "kind":"function",
-                            "modifiers":[  
-                               null
-                            ],
-                            "name":"supportsToken",
-                            "scope":72,
-                            "stateMutability":"pure",
-                            "superFunction":null,
-                            "visibility":"external"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":58,
-                               "name":"ParameterList",
-                               "src":"678:2:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "constant":false,
-                                        "name":"",
-                                        "scope":71,
-                                        "stateVariable":false,
-                                        "storageLocation":"default",
-                                        "type":"bytes32",
-                                        "value":null,
-                                        "visibility":"internal"
-                                     },
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "name":"bytes32",
-                                              "type":"bytes32"
-                                           },
-                                           "id":59,
-                                           "name":"ElementaryTypeName",
-                                           "src":"703:7:0"
-                                        }
-                                     ],
-                                     "id":60,
-                                     "name":"VariableDeclaration",
-                                     "src":"703:7:0"
-                                  }
-                               ],
-                               "id":61,
-                               "name":"ParameterList",
-                               "src":"702:9:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "functionReturnParameters":61
-                                     },
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "argumentTypes":null,
-                                              "isConstant":false,
-                                              "isInlineArray":false,
-                                              "isLValue":false,
-                                              "isPure":true,
-                                              "lValueRequested":false,
-                                              "type":"bytes32"
-                                           },
-                                           "children":[  
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "isConstant":false,
-                                                    "isLValue":false,
-                                                    "isPure":true,
-                                                    "isStructConstructorCall":false,
-                                                    "lValueRequested":false,
-                                                    "names":[  
-                                                       null
-                                                    ],
-                                                    "type":"bytes32",
-                                                    "type_conversion":false
-                                                 },
-                                                 "children":[  
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":[  
-                                                             {  
-                                                                "typeIdentifier":"t_bytes_memory_ptr",
-                                                                "typeString":"bytes memory"
-                                                             }
-                                                          ],
-                                                          "overloadedDeclarations":[  
-                                                             null
-                                                          ],
-                                                          "referencedDeclaration":81,
-                                                          "type":"function (bytes memory) pure returns (bytes32)",
-                                                          "value":"keccak256"
-                                                       },
-                                                       "id":62,
-                                                       "name":"Identifier",
-                                                       "src":"728:9:0"
-                                                    },
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":true,
-                                                          "isStructConstructorCall":false,
-                                                          "lValueRequested":false,
-                                                          "names":[  
-                                                             null
-                                                          ],
-                                                          "type":"bytes memory",
-                                                          "type_conversion":false
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":[  
-                                                                   {  
-                                                                      "typeIdentifier":"t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
-                                                                      "typeString":"literal_string \"Nu Token\""
-                                                                   }
-                                                                ],
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":true,
-                                                                "lValueRequested":false,
-                                                                "member_name":"encodePacked",
-                                                                "referencedDeclaration":null,
-                                                                "type":"function () pure returns (bytes memory)"
-                                                             },
-                                                             "children":[  
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":null,
-                                                                      "overloadedDeclarations":[  
-                                                                         null
-                                                                      ],
-                                                                      "referencedDeclaration":74,
-                                                                      "type":"abi",
-                                                                      "value":"abi"
-                                                                   },
-                                                                   "id":63,
-                                                                   "name":"Identifier",
-                                                                   "src":"738:3:0"
-                                                                }
-                                                             ],
-                                                             "id":64,
-                                                             "name":"MemberAccess",
-                                                             "src":"738:16:0"
-                                                          },
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "hexvalue":"4e7520546f6b656e",
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":true,
-                                                                "lValueRequested":false,
-                                                                "subdenomination":null,
-                                                                "token":"string",
-                                                                "type":"literal_string \"Nu Token\"",
-                                                                "value":"Nu Token"
-                                                             },
-                                                             "id":65,
-                                                             "name":"Literal",
-                                                             "src":"755:10:0"
-                                                          }
-                                                       ],
-                                                       "id":66,
-                                                       "name":"FunctionCall",
-                                                       "src":"738:28:0"
-                                                    }
-                                                 ],
-                                                 "id":67,
-                                                 "name":"FunctionCall",
-                                                 "src":"728:39:0"
-                                              }
-                                           ],
-                                           "id":68,
-                                           "name":"TupleExpression",
-                                           "src":"727:41:0"
-                                        }
-                                     ],
-                                     "id":69,
-                                     "name":"Return",
-                                     "src":"721:47:0"
-                                  }
-                               ],
-                               "id":70,
-                               "name":"Block",
-                               "src":"711:64:0"
-                            }
-                         ],
-                         "id":71,
-                         "name":"FunctionDefinition",
-                         "src":"656:119:0"
-                      }
-                   ],
-                   "id":72,
-                   "name":"ContractDefinition",
-                   "src":"637:140:0"
-                }
-             ],
-             "id":73,
-             "name":"SourceUnit",
-             "src":"0:778:0"
+    "modifier_reentrancy/modifier_reentrancy.sol:ModifierEntrancy" : 
+    {
+      "bin" : "608060405234801561001057600080fd5b5061024f806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561013057600080fd5b505af1158015610144573d6000803e3d6000fd5b505050506040513d602081101561015a57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820795f77e4ec5e578326ae1ce09fab76aa1e3ab6c7f7e8a2a25cdca38095844eb20029",
+      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561013057600080fd5b505af1158015610144573d6000803e3d6000fd5b505050506040513d602081101561015a57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820795f77e4ec5e578326ae1ce09fab76aa1e3ab6c7f7e8a2a25cdca38095844eb20029",
+      "srcmap" : "25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;",
+      "srcmap-runtime" : "25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;;;;;;;;;;;;;;;;;;223:94;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;223:94;617:1;589:12;:24;602:10;589:24;;;;;;;;;;;;;;;;:29;581:38;;;;;;462:10;457:30;;;:32;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;457:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;457:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;457:32:0;;;;;;;;;;;;;;;;424:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;424:28:0;;;414:39;;;;;;:75;406:84;;;;;;310:2;282:12;:24;295:10;282:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;223:94::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
+    }
+  },
+  "sourceList" : 
+  [
+    "modifier_reentrancy/modifier_reentrancy.sol"
+  ],
+  "sources" : 
+  {
+    "modifier_reentrancy/modifier_reentrancy.sol" : 
+    {
+      "AST" : 
+      {
+        "attributes" : 
+        {
+          "absolutePath" : "modifier_reentrancy/modifier_reentrancy.sol",
+          "exportedSymbols" : 
+          {
+            "Bank" : 
+            [
+              78
+            ],
+            "ModifierEntrancy" : 
+            [
+              57
+            ]
           }
-       }
-    },
-    "version":"0.5.8+commit.23d335f2.Linux.g++"
- }
+        },
+        "children" : 
+        [
+          {
+            "attributes" : 
+            {
+              "literals" : 
+              [
+                "solidity",
+                "^",
+                "0.5",
+                ".0"
+              ]
+            },
+            "id" : 1,
+            "name" : "PragmaDirective",
+            "src" : "0:23:0"
+          },
+          {
+            "attributes" : 
+            {
+              "baseContracts" : 
+              [
+                null
+              ],
+              "contractDependencies" : 
+              [
+                null
+              ],
+              "contractKind" : "contract",
+              "documentation" : null,
+              "fullyImplemented" : true,
+              "linearizedBaseContracts" : 
+              [
+                57
+              ],
+              "name" : "ModifierEntrancy",
+              "scope" : 79
+            },
+            "children" : 
+            [
+              {
+                "attributes" : 
+                {
+                  "constant" : false,
+                  "name" : "tokenBalance",
+                  "scope" : 57,
+                  "stateVariable" : true,
+                  "storageLocation" : "default",
+                  "type" : "mapping(address => uint256)",
+                  "value" : null,
+                  "visibility" : "public"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "type" : "mapping(address => uint256)"
+                    },
+                    "children" : 
+                    [
+                      {
+                        "attributes" : 
+                        {
+                          "name" : "address",
+                          "type" : "address"
+                        },
+                        "id" : 2,
+                        "name" : "ElementaryTypeName",
+                        "src" : "64:7:0"
+                      },
+                      {
+                        "attributes" : 
+                        {
+                          "name" : "uint",
+                          "type" : "uint256"
+                        },
+                        "id" : 3,
+                        "name" : "ElementaryTypeName",
+                        "src" : "75:4:0"
+                      }
+                    ],
+                    "id" : 4,
+                    "name" : "Mapping",
+                    "src" : "55:25:0"
+                  }
+                ],
+                "id" : 5,
+                "name" : "VariableDeclaration",
+                "src" : "55:45:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "constant" : true,
+                  "name" : "name",
+                  "scope" : 57,
+                  "stateVariable" : true,
+                  "storageLocation" : "default",
+                  "type" : "string",
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "name" : "string",
+                      "type" : "string"
+                    },
+                    "id" : 6,
+                    "name" : "ElementaryTypeName",
+                    "src" : "104:6:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "argumentTypes" : null,
+                      "hexvalue" : "4e7520546f6b656e",
+                      "isConstant" : false,
+                      "isLValue" : false,
+                      "isPure" : true,
+                      "lValueRequested" : false,
+                      "subdenomination" : null,
+                      "token" : "string",
+                      "type" : "literal_string \"Nu Token\"",
+                      "value" : "Nu Token"
+                    },
+                    "id" : 7,
+                    "name" : "Literal",
+                    "src" : "127:10:0"
+                  }
+                ],
+                "id" : 8,
+                "name" : "VariableDeclaration",
+                "src" : "104:33:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "implemented" : true,
+                  "isConstructor" : false,
+                  "kind" : "function",
+                  "name" : "airDrop",
+                  "scope" : 57,
+                  "stateMutability" : "nonpayable",
+                  "superFunction" : null,
+                  "visibility" : "public"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 9,
+                    "name" : "ParameterList",
+                    "src" : "239:2:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 14,
+                    "name" : "ParameterList",
+                    "src" : "276:0:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "arguments" : null
+                    },
+                    "children" : 
+                    [
+                      {
+                        "attributes" : 
+                        {
+                          "argumentTypes" : null,
+                          "overloadedDeclarations" : 
+                          [
+                            null
+                          ],
+                          "referencedDeclaration" : 56,
+                          "type" : "modifier ()",
+                          "value" : "hasNoBalance"
+                        },
+                        "id" : 10,
+                        "name" : "Identifier",
+                        "src" : "242:12:0"
+                      }
+                    ],
+                    "id" : 11,
+                    "name" : "ModifierInvocation",
+                    "src" : "242:12:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "arguments" : null
+                    },
+                    "children" : 
+                    [
+                      {
+                        "attributes" : 
+                        {
+                          "argumentTypes" : null,
+                          "overloadedDeclarations" : 
+                          [
+                            null
+                          ],
+                          "referencedDeclaration" : 43,
+                          "type" : "modifier ()",
+                          "value" : "supportsToken"
+                        },
+                        "id" : 12,
+                        "name" : "Identifier",
+                        "src" : "255:13:0"
+                      }
+                    ],
+                    "id" : 13,
+                    "name" : "ModifierInvocation",
+                    "src" : "255:13:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "lValueRequested" : false,
+                              "operator" : "+=",
+                              "type" : "uint256"
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "isConstant" : false,
+                                  "isLValue" : true,
+                                  "isPure" : false,
+                                  "lValueRequested" : true,
+                                  "type" : "uint256"
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "overloadedDeclarations" : 
+                                      [
+                                        null
+                                      ],
+                                      "referencedDeclaration" : 5,
+                                      "type" : "mapping(address => uint256)",
+                                      "value" : "tokenBalance"
+                                    },
+                                    "id" : 15,
+                                    "name" : "Identifier",
+                                    "src" : "282:12:0"
+                                  },
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : false,
+                                      "lValueRequested" : false,
+                                      "member_name" : "sender",
+                                      "referencedDeclaration" : null,
+                                      "type" : "address payable"
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "overloadedDeclarations" : 
+                                          [
+                                            null
+                                          ],
+                                          "referencedDeclaration" : 93,
+                                          "type" : "msg",
+                                          "value" : "msg"
+                                        },
+                                        "id" : 16,
+                                        "name" : "Identifier",
+                                        "src" : "295:3:0"
+                                      }
+                                    ],
+                                    "id" : 17,
+                                    "name" : "MemberAccess",
+                                    "src" : "295:10:0"
+                                  }
+                                ],
+                                "id" : 18,
+                                "name" : "IndexAccess",
+                                "src" : "282:24:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "hexvalue" : "3230",
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : true,
+                                  "lValueRequested" : false,
+                                  "subdenomination" : null,
+                                  "token" : "number",
+                                  "type" : "int_const 20",
+                                  "value" : "20"
+                                },
+                                "id" : 19,
+                                "name" : "Literal",
+                                "src" : "310:2:0"
+                              }
+                            ],
+                            "id" : 20,
+                            "name" : "Assignment",
+                            "src" : "282:30:0"
+                          }
+                        ],
+                        "id" : 21,
+                        "name" : "ExpressionStatement",
+                        "src" : "282:30:0"
+                      }
+                    ],
+                    "id" : 22,
+                    "name" : "Block",
+                    "src" : "276:41:0"
+                  }
+                ],
+                "id" : 23,
+                "name" : "FunctionDefinition",
+                "src" : "223:94:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "name" : "supportsToken",
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 24,
+                    "name" : "ParameterList",
+                    "src" : "397:2:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "isStructConstructorCall" : false,
+                              "lValueRequested" : false,
+                              "names" : 
+                              [
+                                null
+                              ],
+                              "type" : "tuple()",
+                              "type_conversion" : false
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : 
+                                  [
+                                    {
+                                      "typeIdentifier" : "t_bool",
+                                      "typeString" : "bool"
+                                    }
+                                  ],
+                                  "overloadedDeclarations" : 
+                                  [
+                                    96,
+                                    97
+                                  ],
+                                  "referencedDeclaration" : 96,
+                                  "type" : "function (bool) pure",
+                                  "value" : "require"
+                                },
+                                "id" : 25,
+                                "name" : "Identifier",
+                                "src" : "406:7:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "commonType" : 
+                                  {
+                                    "typeIdentifier" : "t_bytes32",
+                                    "typeString" : "bytes32"
+                                  },
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : false,
+                                  "lValueRequested" : false,
+                                  "operator" : "==",
+                                  "type" : "bool"
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : true,
+                                      "isStructConstructorCall" : false,
+                                      "lValueRequested" : false,
+                                      "names" : 
+                                      [
+                                        null
+                                      ],
+                                      "type" : "bytes32",
+                                      "type_conversion" : false
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : 
+                                          [
+                                            {
+                                              "typeIdentifier" : "t_bytes_memory_ptr",
+                                              "typeString" : "bytes memory"
+                                            }
+                                          ],
+                                          "overloadedDeclarations" : 
+                                          [
+                                            null
+                                          ],
+                                          "referencedDeclaration" : 87,
+                                          "type" : "function (bytes memory) pure returns (bytes32)",
+                                          "value" : "keccak256"
+                                        },
+                                        "id" : 26,
+                                        "name" : "Identifier",
+                                        "src" : "414:9:0"
+                                      },
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : true,
+                                          "isStructConstructorCall" : false,
+                                          "lValueRequested" : false,
+                                          "names" : 
+                                          [
+                                            null
+                                          ],
+                                          "type" : "bytes memory",
+                                          "type_conversion" : false
+                                        },
+                                        "children" : 
+                                        [
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : 
+                                              [
+                                                {
+                                                  "typeIdentifier" : "t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
+                                                  "typeString" : "literal_string \"Nu Token\""
+                                                }
+                                              ],
+                                              "isConstant" : false,
+                                              "isLValue" : false,
+                                              "isPure" : true,
+                                              "lValueRequested" : false,
+                                              "member_name" : "encodePacked",
+                                              "referencedDeclaration" : null,
+                                              "type" : "function () pure returns (bytes memory)"
+                                            },
+                                            "children" : 
+                                            [
+                                              {
+                                                "attributes" : 
+                                                {
+                                                  "argumentTypes" : null,
+                                                  "overloadedDeclarations" : 
+                                                  [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration" : 80,
+                                                  "type" : "abi",
+                                                  "value" : "abi"
+                                                },
+                                                "id" : 27,
+                                                "name" : "Identifier",
+                                                "src" : "424:3:0"
+                                              }
+                                            ],
+                                            "id" : 28,
+                                            "name" : "MemberAccess",
+                                            "src" : "424:16:0"
+                                          },
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : null,
+                                              "hexvalue" : "4e7520546f6b656e",
+                                              "isConstant" : false,
+                                              "isLValue" : false,
+                                              "isPure" : true,
+                                              "lValueRequested" : false,
+                                              "subdenomination" : null,
+                                              "token" : "string",
+                                              "type" : "literal_string \"Nu Token\"",
+                                              "value" : "Nu Token"
+                                            },
+                                            "id" : 29,
+                                            "name" : "Literal",
+                                            "src" : "441:10:0"
+                                          }
+                                        ],
+                                        "id" : 30,
+                                        "name" : "FunctionCall",
+                                        "src" : "424:28:0"
+                                      }
+                                    ],
+                                    "id" : 31,
+                                    "name" : "FunctionCall",
+                                    "src" : "414:39:0"
+                                  },
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "arguments" : 
+                                      [
+                                        null
+                                      ],
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : false,
+                                      "isStructConstructorCall" : false,
+                                      "lValueRequested" : false,
+                                      "names" : 
+                                      [
+                                        null
+                                      ],
+                                      "type" : "bytes32",
+                                      "type_conversion" : false
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : 
+                                          [
+                                            null
+                                          ],
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : false,
+                                          "lValueRequested" : false,
+                                          "member_name" : "supportsToken",
+                                          "referencedDeclaration" : 77,
+                                          "type" : "function () external returns (bytes32)"
+                                        },
+                                        "children" : 
+                                        [
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : null,
+                                              "isConstant" : false,
+                                              "isLValue" : false,
+                                              "isPure" : false,
+                                              "isStructConstructorCall" : false,
+                                              "lValueRequested" : false,
+                                              "names" : 
+                                              [
+                                                null
+                                              ],
+                                              "type" : "contract Bank",
+                                              "type_conversion" : true
+                                            },
+                                            "children" : 
+                                            [
+                                              {
+                                                "attributes" : 
+                                                {
+                                                  "argumentTypes" : 
+                                                  [
+                                                    {
+                                                      "typeIdentifier" : "t_address_payable",
+                                                      "typeString" : "address payable"
+                                                    }
+                                                  ],
+                                                  "overloadedDeclarations" : 
+                                                  [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration" : 78,
+                                                  "type" : "type(contract Bank)",
+                                                  "value" : "Bank"
+                                                },
+                                                "id" : 32,
+                                                "name" : "Identifier",
+                                                "src" : "457:4:0"
+                                              },
+                                              {
+                                                "attributes" : 
+                                                {
+                                                  "argumentTypes" : null,
+                                                  "isConstant" : false,
+                                                  "isLValue" : false,
+                                                  "isPure" : false,
+                                                  "lValueRequested" : false,
+                                                  "member_name" : "sender",
+                                                  "referencedDeclaration" : null,
+                                                  "type" : "address payable"
+                                                },
+                                                "children" : 
+                                                [
+                                                  {
+                                                    "attributes" : 
+                                                    {
+                                                      "argumentTypes" : null,
+                                                      "overloadedDeclarations" : 
+                                                      [
+                                                        null
+                                                      ],
+                                                      "referencedDeclaration" : 93,
+                                                      "type" : "msg",
+                                                      "value" : "msg"
+                                                    },
+                                                    "id" : 33,
+                                                    "name" : "Identifier",
+                                                    "src" : "462:3:0"
+                                                  }
+                                                ],
+                                                "id" : 34,
+                                                "name" : "MemberAccess",
+                                                "src" : "462:10:0"
+                                              }
+                                            ],
+                                            "id" : 35,
+                                            "name" : "FunctionCall",
+                                            "src" : "457:16:0"
+                                          }
+                                        ],
+                                        "id" : 36,
+                                        "name" : "MemberAccess",
+                                        "src" : "457:30:0"
+                                      }
+                                    ],
+                                    "id" : 37,
+                                    "name" : "FunctionCall",
+                                    "src" : "457:32:0"
+                                  }
+                                ],
+                                "id" : 38,
+                                "name" : "BinaryOperation",
+                                "src" : "414:75:0"
+                              }
+                            ],
+                            "id" : 39,
+                            "name" : "FunctionCall",
+                            "src" : "406:84:0"
+                          }
+                        ],
+                        "id" : 40,
+                        "name" : "ExpressionStatement",
+                        "src" : "406:84:0"
+                      },
+                      {
+                        "id" : 41,
+                        "name" : "PlaceholderStatement",
+                        "src" : "496:1:0"
+                      }
+                    ],
+                    "id" : 42,
+                    "name" : "Block",
+                    "src" : "400:102:0"
+                  }
+                ],
+                "id" : 43,
+                "name" : "ModifierDefinition",
+                "src" : "375:127:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "name" : "hasNoBalance",
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 44,
+                    "name" : "ParameterList",
+                    "src" : "573:0:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "isStructConstructorCall" : false,
+                              "lValueRequested" : false,
+                              "names" : 
+                              [
+                                null
+                              ],
+                              "type" : "tuple()",
+                              "type_conversion" : false
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : 
+                                  [
+                                    {
+                                      "typeIdentifier" : "t_bool",
+                                      "typeString" : "bool"
+                                    }
+                                  ],
+                                  "overloadedDeclarations" : 
+                                  [
+                                    96,
+                                    97
+                                  ],
+                                  "referencedDeclaration" : 96,
+                                  "type" : "function (bool) pure",
+                                  "value" : "require"
+                                },
+                                "id" : 45,
+                                "name" : "Identifier",
+                                "src" : "581:7:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "commonType" : 
+                                  {
+                                    "typeIdentifier" : "t_uint256",
+                                    "typeString" : "uint256"
+                                  },
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : false,
+                                  "lValueRequested" : false,
+                                  "operator" : "==",
+                                  "type" : "bool"
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "isConstant" : false,
+                                      "isLValue" : true,
+                                      "isPure" : false,
+                                      "lValueRequested" : false,
+                                      "type" : "uint256"
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "overloadedDeclarations" : 
+                                          [
+                                            null
+                                          ],
+                                          "referencedDeclaration" : 5,
+                                          "type" : "mapping(address => uint256)",
+                                          "value" : "tokenBalance"
+                                        },
+                                        "id" : 46,
+                                        "name" : "Identifier",
+                                        "src" : "589:12:0"
+                                      },
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : false,
+                                          "lValueRequested" : false,
+                                          "member_name" : "sender",
+                                          "referencedDeclaration" : null,
+                                          "type" : "address payable"
+                                        },
+                                        "children" : 
+                                        [
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : null,
+                                              "overloadedDeclarations" : 
+                                              [
+                                                null
+                                              ],
+                                              "referencedDeclaration" : 93,
+                                              "type" : "msg",
+                                              "value" : "msg"
+                                            },
+                                            "id" : 47,
+                                            "name" : "Identifier",
+                                            "src" : "602:3:0"
+                                          }
+                                        ],
+                                        "id" : 48,
+                                        "name" : "MemberAccess",
+                                        "src" : "602:10:0"
+                                      }
+                                    ],
+                                    "id" : 49,
+                                    "name" : "IndexAccess",
+                                    "src" : "589:24:0"
+                                  },
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "hexvalue" : "30",
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : true,
+                                      "lValueRequested" : false,
+                                      "subdenomination" : null,
+                                      "token" : "number",
+                                      "type" : "int_const 0",
+                                      "value" : "0"
+                                    },
+                                    "id" : 50,
+                                    "name" : "Literal",
+                                    "src" : "617:1:0"
+                                  }
+                                ],
+                                "id" : 51,
+                                "name" : "BinaryOperation",
+                                "src" : "589:29:0"
+                              }
+                            ],
+                            "id" : 52,
+                            "name" : "FunctionCall",
+                            "src" : "581:38:0"
+                          }
+                        ],
+                        "id" : 53,
+                        "name" : "ExpressionStatement",
+                        "src" : "581:38:0"
+                      },
+                      {
+                        "id" : 54,
+                        "name" : "PlaceholderStatement",
+                        "src" : "627:1:0"
+                      }
+                    ],
+                    "id" : 55,
+                    "name" : "Block",
+                    "src" : "573:60:0"
+                  }
+                ],
+                "id" : 56,
+                "name" : "ModifierDefinition",
+                "src" : "551:82:0"
+              }
+            ],
+            "id" : 57,
+            "name" : "ContractDefinition",
+            "src" : "25:610:0"
+          },
+          {
+            "attributes" : 
+            {
+              "baseContracts" : 
+              [
+                null
+              ],
+              "contractDependencies" : 
+              [
+                null
+              ],
+              "contractKind" : "contract",
+              "documentation" : null,
+              "fullyImplemented" : true,
+              "linearizedBaseContracts" : 
+              [
+                78
+              ],
+              "name" : "Bank",
+              "scope" : 79
+            },
+            "children" : 
+            [
+              {
+                "attributes" : 
+                {
+                  "constant" : false,
+                  "name" : "state_var",
+                  "scope" : 78,
+                  "stateVariable" : true,
+                  "storageLocation" : "default",
+                  "type" : "uint256",
+                  "value" : null,
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "name" : "uint",
+                      "type" : "uint256"
+                    },
+                    "id" : 58,
+                    "name" : "ElementaryTypeName",
+                    "src" : "656:4:0"
+                  }
+                ],
+                "id" : 59,
+                "name" : "VariableDeclaration",
+                "src" : "656:14:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "implemented" : true,
+                  "isConstructor" : false,
+                  "kind" : "function",
+                  "modifiers" : 
+                  [
+                    null
+                  ],
+                  "name" : "supportsToken",
+                  "scope" : 78,
+                  "stateMutability" : "nonpayable",
+                  "superFunction" : null,
+                  "visibility" : "external"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 60,
+                    "name" : "ParameterList",
+                    "src" : "698:2:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "attributes" : 
+                        {
+                          "constant" : false,
+                          "name" : "",
+                          "scope" : 77,
+                          "stateVariable" : false,
+                          "storageLocation" : "default",
+                          "type" : "bytes32",
+                          "value" : null,
+                          "visibility" : "internal"
+                        },
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "name" : "bytes32",
+                              "type" : "bytes32"
+                            },
+                            "id" : 61,
+                            "name" : "ElementaryTypeName",
+                            "src" : "718:7:0"
+                          }
+                        ],
+                        "id" : 62,
+                        "name" : "VariableDeclaration",
+                        "src" : "718:7:0"
+                      }
+                    ],
+                    "id" : 63,
+                    "name" : "ParameterList",
+                    "src" : "717:9:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "lValueRequested" : false,
+                              "operator" : "=",
+                              "type" : "uint256"
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "overloadedDeclarations" : 
+                                  [
+                                    null
+                                  ],
+                                  "referencedDeclaration" : 59,
+                                  "type" : "uint256",
+                                  "value" : "state_var"
+                                },
+                                "id" : 64,
+                                "name" : "Identifier",
+                                "src" : "736:9:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "hexvalue" : "31",
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : true,
+                                  "lValueRequested" : false,
+                                  "subdenomination" : null,
+                                  "token" : "number",
+                                  "type" : "int_const 1",
+                                  "value" : "1"
+                                },
+                                "id" : 65,
+                                "name" : "Literal",
+                                "src" : "748:1:0"
+                              }
+                            ],
+                            "id" : 66,
+                            "name" : "Assignment",
+                            "src" : "736:13:0"
+                          }
+                        ],
+                        "id" : 67,
+                        "name" : "ExpressionStatement",
+                        "src" : "736:13:0"
+                      },
+                      {
+                        "attributes" : 
+                        {
+                          "functionReturnParameters" : 63
+                        },
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isInlineArray" : false,
+                              "isLValue" : false,
+                              "isPure" : true,
+                              "lValueRequested" : false,
+                              "type" : "bytes32"
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : true,
+                                  "isStructConstructorCall" : false,
+                                  "lValueRequested" : false,
+                                  "names" : 
+                                  [
+                                    null
+                                  ],
+                                  "type" : "bytes32",
+                                  "type_conversion" : false
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : 
+                                      [
+                                        {
+                                          "typeIdentifier" : "t_bytes_memory_ptr",
+                                          "typeString" : "bytes memory"
+                                        }
+                                      ],
+                                      "overloadedDeclarations" : 
+                                      [
+                                        null
+                                      ],
+                                      "referencedDeclaration" : 87,
+                                      "type" : "function (bytes memory) pure returns (bytes32)",
+                                      "value" : "keccak256"
+                                    },
+                                    "id" : 68,
+                                    "name" : "Identifier",
+                                    "src" : "766:9:0"
+                                  },
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : true,
+                                      "isStructConstructorCall" : false,
+                                      "lValueRequested" : false,
+                                      "names" : 
+                                      [
+                                        null
+                                      ],
+                                      "type" : "bytes memory",
+                                      "type_conversion" : false
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : 
+                                          [
+                                            {
+                                              "typeIdentifier" : "t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
+                                              "typeString" : "literal_string \"Nu Token\""
+                                            }
+                                          ],
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : true,
+                                          "lValueRequested" : false,
+                                          "member_name" : "encodePacked",
+                                          "referencedDeclaration" : null,
+                                          "type" : "function () pure returns (bytes memory)"
+                                        },
+                                        "children" : 
+                                        [
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : null,
+                                              "overloadedDeclarations" : 
+                                              [
+                                                null
+                                              ],
+                                              "referencedDeclaration" : 80,
+                                              "type" : "abi",
+                                              "value" : "abi"
+                                            },
+                                            "id" : 69,
+                                            "name" : "Identifier",
+                                            "src" : "776:3:0"
+                                          }
+                                        ],
+                                        "id" : 70,
+                                        "name" : "MemberAccess",
+                                        "src" : "776:16:0"
+                                      },
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "hexvalue" : "4e7520546f6b656e",
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : true,
+                                          "lValueRequested" : false,
+                                          "subdenomination" : null,
+                                          "token" : "string",
+                                          "type" : "literal_string \"Nu Token\"",
+                                          "value" : "Nu Token"
+                                        },
+                                        "id" : 71,
+                                        "name" : "Literal",
+                                        "src" : "793:10:0"
+                                      }
+                                    ],
+                                    "id" : 72,
+                                    "name" : "FunctionCall",
+                                    "src" : "776:28:0"
+                                  }
+                                ],
+                                "id" : 73,
+                                "name" : "FunctionCall",
+                                "src" : "766:39:0"
+                              }
+                            ],
+                            "id" : 74,
+                            "name" : "TupleExpression",
+                            "src" : "765:41:0"
+                          }
+                        ],
+                        "id" : 75,
+                        "name" : "Return",
+                        "src" : "759:47:0"
+                      }
+                    ],
+                    "id" : 76,
+                    "name" : "Block",
+                    "src" : "726:87:0"
+                  }
+                ],
+                "id" : 77,
+                "name" : "FunctionDefinition",
+                "src" : "676:137:0"
+              }
+            ],
+            "id" : 78,
+            "name" : "ContractDefinition",
+            "src" : "637:178:0"
+          }
+        ],
+        "id" : 79,
+        "name" : "SourceUnit",
+        "src" : "0:816:0"
+      }
+    }
+  },
+  "version" : "0.5.6+commit.b259423e.Linux.g++"
+}

--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.json
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.json
@@ -3,17 +3,17 @@
   {
     "modifier_reentrancy/modifier_reentrancy.sol:Bank" : 
     {
-      "bin" : "6080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a723058205a56a5f23b6b3f606d0d5d74f269aeb0e536c958929f934b6107e315b73324390029",
-      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a723058205a56a5f23b6b3f606d0d5d74f269aeb0e536c958929f934b6107e315b73324390029",
-      "srcmap" : "637:135:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:135:0;;;;;;;",
-      "srcmap-runtime" : "637:135:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:135:0;;;;;;;;;;;;;;;;;;;656:114;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;698:7;733:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;733:28:0;;;723:39;;;;;;716:47;;656:114;:::o"
+      "bin" : "6080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820516f6da551345875689b811a558c4be0c589f007e3e03432d0b50691f88c90ff0029",
+      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820516f6da551345875689b811a558c4be0c589f007e3e03432d0b50691f88c90ff0029",
+      "srcmap" : "692:135:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;692:135:0;;;;;;;",
+      "srcmap-runtime" : "692:135:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;692:135:0;;;;;;;;;;;;;;;;;;;711:114;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;753:7;789:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;789:28:0;;;779:39;;;;;;772:46;;711:114;:::o"
     },
     "modifier_reentrancy/modifier_reentrancy.sol:ModifierEntrancy" : 
     {
-      "bin" : "608060405234801561001057600080fd5b5061024f806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561013057600080fd5b505af1158015610144573d6000803e3d6000fd5b505050506040513d602081101561015a57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820524c21dfec95455436bf89f8c21b317442716a28516bfa88b5d64a83b988ff920029",
-      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561013057600080fd5b505af1158015610144573d6000803e3d6000fd5b505050506040513d602081101561015a57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820524c21dfec95455436bf89f8c21b317442716a28516bfa88b5d64a83b988ff920029",
-      "srcmap" : "25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;",
-      "srcmap-runtime" : "25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;;;;;;;;;;;;;;;;;;223:94;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;223:94;617:1;589:12;:24;602:10;589:24;;;;;;;;;;;;;;;;:29;581:38;;;;;;462:10;457:30;;;:32;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;457:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;457:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;457:32:0;;;;;;;;;;;;;;;;424:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;424:28:0;;;414:39;;;;;;:75;406:84;;;;;;310:2;282:12;:24;295:10;282:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;223:94::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
+      "bin" : "608060405234801561001057600080fd5b5060405161001d9061007f565b604051809103906000f080158015610039573d6000803e3d6000fd5b50600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555061008b565b60e1806102c083390190565b6102268061009a6000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506101e2565b6040518082815260200191505060405180910390f35b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561010757600080fd5b505af115801561011b573d6000803e3d6000fd5b505050506040513d602081101561013157600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461019357600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820d051c80d6d17715bb2bd4624cf7caed3ad5ed91e92205efea92994cd27634ef900296080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820516f6da551345875689b811a558c4be0c589f007e3e03432d0b50691f88c90ff0029",
+      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506101e2565b6040518082815260200191505060405180910390f35b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561010757600080fd5b505af115801561011b573d6000803e3d6000fd5b505050506040513d602081101561013157600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461019357600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820d051c80d6d17715bb2bd4624cf7caed3ad5ed91e92205efea92994cd27634ef90029",
+      "srcmap" : "25:665:0:-;;;154:50;8:9:-1;5:2;;;30:1;27;20:12;5:2;154:50:0;189:10;;;;;:::i;:::-;;;;;;;;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;189:10:0;182:4;;:17;;;;;;;;;;;;;;;;;;25:665;;;;;;;;;;:::o;:::-;;;;;;;",
+      "srcmap-runtime" : "25:665:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:665:0;;;;;;;;;;;;;;;;;;;;;;;;289:94;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;289:94;522:4;;;;;;;;;;;:18;;;:20;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;522:20:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;522:20:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;522:20:0;;;;;;;;;;;;;;;;489:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;489:28:0;;;479:39;;;;;;:63;471:72;;;;;;376:2;348:12;:24;361:10;348:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;289:94::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
     }
   },
   "sourceList" : 
@@ -33,7 +33,7 @@
           {
             "Bank" : 
             [
-              72
+              71
             ],
             "ModifierEntrancy" : 
             [
@@ -67,7 +67,7 @@
               ],
               "contractDependencies" : 
               [
-                null
+                71
               ],
               "contractKind" : "contract",
               "documentation" : null,
@@ -77,7 +77,7 @@
                 57
               ],
               "name" : "ModifierEntrancy",
-              "scope" : 73
+              "scope" : 72
             },
             "children" : 
             [
@@ -181,6 +181,196 @@
               {
                 "attributes" : 
                 {
+                  "constant" : false,
+                  "name" : "bank",
+                  "scope" : 57,
+                  "stateVariable" : true,
+                  "storageLocation" : "default",
+                  "type" : "contract Bank",
+                  "value" : null,
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "contractScope" : null,
+                      "name" : "Bank",
+                      "referencedDeclaration" : 71,
+                      "type" : "contract Bank"
+                    },
+                    "id" : 9,
+                    "name" : "UserDefinedTypeName",
+                    "src" : "141:4:0"
+                  }
+                ],
+                "id" : 10,
+                "name" : "VariableDeclaration",
+                "src" : "141:9:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "implemented" : true,
+                  "isConstructor" : true,
+                  "kind" : "constructor",
+                  "modifiers" : 
+                  [
+                    null
+                  ],
+                  "name" : "",
+                  "scope" : 57,
+                  "stateMutability" : "nonpayable",
+                  "superFunction" : null,
+                  "visibility" : "public"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 11,
+                    "name" : "ParameterList",
+                    "src" : "165:2:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 12,
+                    "name" : "ParameterList",
+                    "src" : "174:0:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "lValueRequested" : false,
+                              "operator" : "=",
+                              "type" : "contract Bank"
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "overloadedDeclarations" : 
+                                  [
+                                    null
+                                  ],
+                                  "referencedDeclaration" : 10,
+                                  "type" : "contract Bank",
+                                  "value" : "bank"
+                                },
+                                "id" : 13,
+                                "name" : "Identifier",
+                                "src" : "182:4:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "arguments" : 
+                                  [
+                                    null
+                                  ],
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : false,
+                                  "isStructConstructorCall" : false,
+                                  "lValueRequested" : false,
+                                  "names" : 
+                                  [
+                                    null
+                                  ],
+                                  "type" : "contract Bank",
+                                  "type_conversion" : false
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : 
+                                      [
+                                        null
+                                      ],
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : false,
+                                      "lValueRequested" : false,
+                                      "type" : "function () returns (contract Bank)"
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "contractScope" : null,
+                                          "name" : "Bank",
+                                          "referencedDeclaration" : 71,
+                                          "type" : "contract Bank"
+                                        },
+                                        "id" : 14,
+                                        "name" : "UserDefinedTypeName",
+                                        "src" : "193:4:0"
+                                      }
+                                    ],
+                                    "id" : 15,
+                                    "name" : "NewExpression",
+                                    "src" : "189:8:0"
+                                  }
+                                ],
+                                "id" : 16,
+                                "name" : "FunctionCall",
+                                "src" : "189:10:0"
+                              }
+                            ],
+                            "id" : 17,
+                            "name" : "Assignment",
+                            "src" : "182:17:0"
+                          }
+                        ],
+                        "id" : 18,
+                        "name" : "ExpressionStatement",
+                        "src" : "182:17:0"
+                      }
+                    ],
+                    "id" : 19,
+                    "name" : "Block",
+                    "src" : "174:30:0"
+                  }
+                ],
+                "id" : 20,
+                "name" : "FunctionDefinition",
+                "src" : "154:50:0"
+              },
+              {
+                "attributes" : 
+                {
                   "documentation" : null,
                   "implemented" : true,
                   "isConstructor" : false,
@@ -202,9 +392,9 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 9,
+                    "id" : 21,
                     "name" : "ParameterList",
-                    "src" : "239:2:0"
+                    "src" : "305:2:0"
                   },
                   {
                     "attributes" : 
@@ -215,9 +405,9 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 14,
+                    "id" : 26,
                     "name" : "ParameterList",
-                    "src" : "276:0:0"
+                    "src" : "342:0:0"
                   },
                   {
                     "attributes" : 
@@ -238,14 +428,14 @@
                           "type" : "modifier ()",
                           "value" : "hasNoBalance"
                         },
-                        "id" : 10,
+                        "id" : 22,
                         "name" : "Identifier",
-                        "src" : "242:12:0"
+                        "src" : "308:12:0"
                       }
                     ],
-                    "id" : 11,
+                    "id" : 23,
                     "name" : "ModifierInvocation",
-                    "src" : "242:12:0"
+                    "src" : "308:12:0"
                   },
                   {
                     "attributes" : 
@@ -262,18 +452,18 @@
                           [
                             null
                           ],
-                          "referencedDeclaration" : 43,
+                          "referencedDeclaration" : 52,
                           "type" : "modifier ()",
                           "value" : "supportsToken"
                         },
-                        "id" : 12,
+                        "id" : 24,
                         "name" : "Identifier",
-                        "src" : "255:13:0"
+                        "src" : "321:13:0"
                       }
                     ],
-                    "id" : 13,
+                    "id" : 25,
                     "name" : "ModifierInvocation",
-                    "src" : "255:13:0"
+                    "src" : "321:13:0"
                   },
                   {
                     "children" : 
@@ -318,9 +508,9 @@
                                       "type" : "mapping(address => uint256)",
                                       "value" : "tokenBalance"
                                     },
-                                    "id" : 15,
+                                    "id" : 27,
                                     "name" : "Identifier",
-                                    "src" : "282:12:0"
+                                    "src" : "348:12:0"
                                   },
                                   {
                                     "attributes" : 
@@ -344,23 +534,23 @@
                                           [
                                             null
                                           ],
-                                          "referencedDeclaration" : 87,
+                                          "referencedDeclaration" : 86,
                                           "type" : "msg",
                                           "value" : "msg"
                                         },
-                                        "id" : 16,
+                                        "id" : 28,
                                         "name" : "Identifier",
-                                        "src" : "295:3:0"
+                                        "src" : "361:3:0"
                                       }
                                     ],
-                                    "id" : 17,
+                                    "id" : 29,
                                     "name" : "MemberAccess",
-                                    "src" : "295:10:0"
+                                    "src" : "361:10:0"
                                   }
                                 ],
-                                "id" : 18,
+                                "id" : 30,
                                 "name" : "IndexAccess",
-                                "src" : "282:24:0"
+                                "src" : "348:24:0"
                               },
                               {
                                 "attributes" : 
@@ -376,29 +566,29 @@
                                   "type" : "int_const 20",
                                   "value" : "20"
                                 },
-                                "id" : 19,
+                                "id" : 31,
                                 "name" : "Literal",
-                                "src" : "310:2:0"
+                                "src" : "376:2:0"
                               }
                             ],
-                            "id" : 20,
+                            "id" : 32,
                             "name" : "Assignment",
-                            "src" : "282:30:0"
+                            "src" : "348:30:0"
                           }
                         ],
-                        "id" : 21,
+                        "id" : 33,
                         "name" : "ExpressionStatement",
-                        "src" : "282:30:0"
+                        "src" : "348:30:0"
                       }
                     ],
-                    "id" : 22,
+                    "id" : 34,
                     "name" : "Block",
-                    "src" : "276:41:0"
+                    "src" : "342:41:0"
                   }
                 ],
-                "id" : 23,
+                "id" : 35,
                 "name" : "FunctionDefinition",
-                "src" : "223:94:0"
+                "src" : "289:94:0"
               },
               {
                 "attributes" : 
@@ -418,9 +608,9 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 24,
+                    "id" : 36,
                     "name" : "ParameterList",
-                    "src" : "397:2:0"
+                    "src" : "462:2:0"
                   },
                   {
                     "children" : 
@@ -458,16 +648,16 @@
                                   ],
                                   "overloadedDeclarations" : 
                                   [
-                                    90,
-                                    91
+                                    89,
+                                    90
                                   ],
-                                  "referencedDeclaration" : 90,
+                                  "referencedDeclaration" : 89,
                                   "type" : "function (bool) pure",
                                   "value" : "require"
                                 },
-                                "id" : 25,
+                                "id" : 37,
                                 "name" : "Identifier",
-                                "src" : "406:7:0"
+                                "src" : "471:7:0"
                               },
                               {
                                 "attributes" : 
@@ -519,13 +709,13 @@
                                           [
                                             null
                                           ],
-                                          "referencedDeclaration" : 81,
+                                          "referencedDeclaration" : 80,
                                           "type" : "function (bytes memory) pure returns (bytes32)",
                                           "value" : "keccak256"
                                         },
-                                        "id" : 26,
+                                        "id" : 38,
                                         "name" : "Identifier",
-                                        "src" : "414:9:0"
+                                        "src" : "479:9:0"
                                       },
                                       {
                                         "attributes" : 
@@ -573,18 +763,18 @@
                                                   [
                                                     null
                                                   ],
-                                                  "referencedDeclaration" : 74,
+                                                  "referencedDeclaration" : 73,
                                                   "type" : "abi",
                                                   "value" : "abi"
                                                 },
-                                                "id" : 27,
+                                                "id" : 39,
                                                 "name" : "Identifier",
-                                                "src" : "424:3:0"
+                                                "src" : "489:3:0"
                                               }
                                             ],
-                                            "id" : 28,
+                                            "id" : 40,
                                             "name" : "MemberAccess",
-                                            "src" : "424:16:0"
+                                            "src" : "489:16:0"
                                           },
                                           {
                                             "attributes" : 
@@ -600,19 +790,19 @@
                                               "type" : "literal_string \"Nu Token\"",
                                               "value" : "Nu Token"
                                             },
-                                            "id" : 29,
+                                            "id" : 41,
                                             "name" : "Literal",
-                                            "src" : "441:10:0"
+                                            "src" : "506:10:0"
                                           }
                                         ],
-                                        "id" : 30,
+                                        "id" : 42,
                                         "name" : "FunctionCall",
-                                        "src" : "424:28:0"
+                                        "src" : "489:28:0"
                                       }
                                     ],
-                                    "id" : 31,
+                                    "id" : 43,
                                     "name" : "FunctionCall",
-                                    "src" : "414:39:0"
+                                    "src" : "479:39:0"
                                   },
                                   {
                                     "attributes" : 
@@ -648,7 +838,7 @@
                                           "isPure" : false,
                                           "lValueRequested" : false,
                                           "member_name" : "supportsToken",
-                                          "referencedDeclaration" : 71,
+                                          "referencedDeclaration" : 70,
                                           "type" : "function () external returns (bytes32)"
                                         },
                                         "children" : 
@@ -657,121 +847,57 @@
                                             "attributes" : 
                                             {
                                               "argumentTypes" : null,
-                                              "isConstant" : false,
-                                              "isLValue" : false,
-                                              "isPure" : false,
-                                              "isStructConstructorCall" : false,
-                                              "lValueRequested" : false,
-                                              "names" : 
+                                              "overloadedDeclarations" : 
                                               [
                                                 null
                                               ],
+                                              "referencedDeclaration" : 10,
                                               "type" : "contract Bank",
-                                              "type_conversion" : true
+                                              "value" : "bank"
                                             },
-                                            "children" : 
-                                            [
-                                              {
-                                                "attributes" : 
-                                                {
-                                                  "argumentTypes" : 
-                                                  [
-                                                    {
-                                                      "typeIdentifier" : "t_address_payable",
-                                                      "typeString" : "address payable"
-                                                    }
-                                                  ],
-                                                  "overloadedDeclarations" : 
-                                                  [
-                                                    null
-                                                  ],
-                                                  "referencedDeclaration" : 72,
-                                                  "type" : "type(contract Bank)",
-                                                  "value" : "Bank"
-                                                },
-                                                "id" : 32,
-                                                "name" : "Identifier",
-                                                "src" : "457:4:0"
-                                              },
-                                              {
-                                                "attributes" : 
-                                                {
-                                                  "argumentTypes" : null,
-                                                  "isConstant" : false,
-                                                  "isLValue" : false,
-                                                  "isPure" : false,
-                                                  "lValueRequested" : false,
-                                                  "member_name" : "sender",
-                                                  "referencedDeclaration" : null,
-                                                  "type" : "address payable"
-                                                },
-                                                "children" : 
-                                                [
-                                                  {
-                                                    "attributes" : 
-                                                    {
-                                                      "argumentTypes" : null,
-                                                      "overloadedDeclarations" : 
-                                                      [
-                                                        null
-                                                      ],
-                                                      "referencedDeclaration" : 87,
-                                                      "type" : "msg",
-                                                      "value" : "msg"
-                                                    },
-                                                    "id" : 33,
-                                                    "name" : "Identifier",
-                                                    "src" : "462:3:0"
-                                                  }
-                                                ],
-                                                "id" : 34,
-                                                "name" : "MemberAccess",
-                                                "src" : "462:10:0"
-                                              }
-                                            ],
-                                            "id" : 35,
-                                            "name" : "FunctionCall",
-                                            "src" : "457:16:0"
+                                            "id" : 44,
+                                            "name" : "Identifier",
+                                            "src" : "522:4:0"
                                           }
                                         ],
-                                        "id" : 36,
+                                        "id" : 45,
                                         "name" : "MemberAccess",
-                                        "src" : "457:30:0"
+                                        "src" : "522:18:0"
                                       }
                                     ],
-                                    "id" : 37,
+                                    "id" : 46,
                                     "name" : "FunctionCall",
-                                    "src" : "457:32:0"
+                                    "src" : "522:20:0"
                                   }
                                 ],
-                                "id" : 38,
+                                "id" : 47,
                                 "name" : "BinaryOperation",
-                                "src" : "414:75:0"
+                                "src" : "479:63:0"
                               }
                             ],
-                            "id" : 39,
+                            "id" : 48,
                             "name" : "FunctionCall",
-                            "src" : "406:84:0"
+                            "src" : "471:72:0"
                           }
                         ],
-                        "id" : 40,
+                        "id" : 49,
                         "name" : "ExpressionStatement",
-                        "src" : "406:84:0"
+                        "src" : "471:72:0"
                       },
                       {
-                        "id" : 41,
+                        "id" : 50,
                         "name" : "PlaceholderStatement",
-                        "src" : "496:1:0"
+                        "src" : "549:1:0"
                       }
                     ],
-                    "id" : 42,
+                    "id" : 51,
                     "name" : "Block",
-                    "src" : "400:102:0"
+                    "src" : "465:90:0"
                   }
                 ],
-                "id" : 43,
+                "id" : 52,
                 "name" : "ModifierDefinition",
-                "src" : "375:127:0"
+                "src" : "440:115:0"
               },
               {
                 "attributes" : 
@@ -791,195 +917,32 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 44,
+                    "id" : 53,
                     "name" : "ParameterList",
-                    "src" : "573:0:0"
+                    "src" : "626:0:0"
                   },
                   {
                     "children" : 
                     [
                       {
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "isConstant" : false,
-                              "isLValue" : false,
-                              "isPure" : false,
-                              "isStructConstructorCall" : false,
-                              "lValueRequested" : false,
-                              "names" : 
-                              [
-                                null
-                              ],
-                              "type" : "tuple()",
-                              "type_conversion" : false
-                            },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : 
-                                  [
-                                    {
-                                      "typeIdentifier" : "t_bool",
-                                      "typeString" : "bool"
-                                    }
-                                  ],
-                                  "overloadedDeclarations" : 
-                                  [
-                                    90,
-                                    91
-                                  ],
-                                  "referencedDeclaration" : 90,
-                                  "type" : "function (bool) pure",
-                                  "value" : "require"
-                                },
-                                "id" : 45,
-                                "name" : "Identifier",
-                                "src" : "581:7:0"
-                              },
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "commonType" : 
-                                  {
-                                    "typeIdentifier" : "t_uint256",
-                                    "typeString" : "uint256"
-                                  },
-                                  "isConstant" : false,
-                                  "isLValue" : false,
-                                  "isPure" : false,
-                                  "lValueRequested" : false,
-                                  "operator" : "==",
-                                  "type" : "bool"
-                                },
-                                "children" : 
-                                [
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "isConstant" : false,
-                                      "isLValue" : true,
-                                      "isPure" : false,
-                                      "lValueRequested" : false,
-                                      "type" : "uint256"
-                                    },
-                                    "children" : 
-                                    [
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "overloadedDeclarations" : 
-                                          [
-                                            null
-                                          ],
-                                          "referencedDeclaration" : 5,
-                                          "type" : "mapping(address => uint256)",
-                                          "value" : "tokenBalance"
-                                        },
-                                        "id" : 46,
-                                        "name" : "Identifier",
-                                        "src" : "589:12:0"
-                                      },
-                                      {
-                                        "attributes" : 
-                                        {
-                                          "argumentTypes" : null,
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : false,
-                                          "lValueRequested" : false,
-                                          "member_name" : "sender",
-                                          "referencedDeclaration" : null,
-                                          "type" : "address payable"
-                                        },
-                                        "children" : 
-                                        [
-                                          {
-                                            "attributes" : 
-                                            {
-                                              "argumentTypes" : null,
-                                              "overloadedDeclarations" : 
-                                              [
-                                                null
-                                              ],
-                                              "referencedDeclaration" : 87,
-                                              "type" : "msg",
-                                              "value" : "msg"
-                                            },
-                                            "id" : 47,
-                                            "name" : "Identifier",
-                                            "src" : "602:3:0"
-                                          }
-                                        ],
-                                        "id" : 48,
-                                        "name" : "MemberAccess",
-                                        "src" : "602:10:0"
-                                      }
-                                    ],
-                                    "id" : 49,
-                                    "name" : "IndexAccess",
-                                    "src" : "589:24:0"
-                                  },
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
-                                      "hexvalue" : "30",
-                                      "isConstant" : false,
-                                      "isLValue" : false,
-                                      "isPure" : true,
-                                      "lValueRequested" : false,
-                                      "subdenomination" : null,
-                                      "token" : "number",
-                                      "type" : "int_const 0",
-                                      "value" : "0"
-                                    },
-                                    "id" : 50,
-                                    "name" : "Literal",
-                                    "src" : "617:1:0"
-                                  }
-                                ],
-                                "id" : 51,
-                                "name" : "BinaryOperation",
-                                "src" : "589:29:0"
-                              }
-                            ],
-                            "id" : 52,
-                            "name" : "FunctionCall",
-                            "src" : "581:38:0"
-                          }
-                        ],
-                        "id" : 53,
-                        "name" : "ExpressionStatement",
-                        "src" : "581:38:0"
-                      },
-                      {
                         "id" : 54,
                         "name" : "PlaceholderStatement",
-                        "src" : "627:1:0"
+                        "src" : "682:1:0"
                       }
                     ],
                     "id" : 55,
                     "name" : "Block",
-                    "src" : "573:60:0"
+                    "src" : "626:62:0"
                   }
                 ],
                 "id" : 56,
                 "name" : "ModifierDefinition",
-                "src" : "551:82:0"
+                "src" : "604:84:0"
               }
             ],
             "id" : 57,
             "name" : "ContractDefinition",
-            "src" : "25:610:0"
+            "src" : "25:665:0"
           },
           {
             "attributes" : 
@@ -997,10 +960,10 @@
               "fullyImplemented" : true,
               "linearizedBaseContracts" : 
               [
-                72
+                71
               ],
               "name" : "Bank",
-              "scope" : 73
+              "scope" : 72
             },
             "children" : 
             [
@@ -1016,7 +979,7 @@
                     null
                   ],
                   "name" : "supportsToken",
-                  "scope" : 72,
+                  "scope" : 71,
                   "stateMutability" : "nonpayable",
                   "superFunction" : null,
                   "visibility" : "external"
@@ -1034,7 +997,7 @@
                     "children" : [],
                     "id" : 58,
                     "name" : "ParameterList",
-                    "src" : "678:2:0"
+                    "src" : "733:2:0"
                   },
                   {
                     "children" : 
@@ -1044,7 +1007,7 @@
                         {
                           "constant" : false,
                           "name" : "",
-                          "scope" : 71,
+                          "scope" : 70,
                           "stateVariable" : false,
                           "storageLocation" : "default",
                           "type" : "bytes32",
@@ -1061,17 +1024,17 @@
                             },
                             "id" : 59,
                             "name" : "ElementaryTypeName",
-                            "src" : "698:7:0"
+                            "src" : "753:7:0"
                           }
                         ],
                         "id" : 60,
                         "name" : "VariableDeclaration",
-                        "src" : "698:7:0"
+                        "src" : "753:7:0"
                       }
                     ],
                     "id" : 61,
                     "name" : "ParameterList",
-                    "src" : "697:9:0"
+                    "src" : "752:9:0"
                   },
                   {
                     "children" : 
@@ -1088,14 +1051,41 @@
                             {
                               "argumentTypes" : null,
                               "isConstant" : false,
-                              "isInlineArray" : false,
                               "isLValue" : false,
                               "isPure" : true,
+                              "isStructConstructorCall" : false,
                               "lValueRequested" : false,
-                              "type" : "bytes32"
+                              "names" : 
+                              [
+                                null
+                              ],
+                              "type" : "bytes32",
+                              "type_conversion" : false
                             },
                             "children" : 
                             [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : 
+                                  [
+                                    {
+                                      "typeIdentifier" : "t_bytes_memory_ptr",
+                                      "typeString" : "bytes memory"
+                                    }
+                                  ],
+                                  "overloadedDeclarations" : 
+                                  [
+                                    null
+                                  ],
+                                  "referencedDeclaration" : 80,
+                                  "type" : "function (bytes memory) pure returns (bytes32)",
+                                  "value" : "keccak256"
+                                },
+                                "id" : 62,
+                                "name" : "Identifier",
+                                "src" : "779:9:0"
+                              },
                               {
                                 "attributes" : 
                                 {
@@ -1109,7 +1099,7 @@
                                   [
                                     null
                                   ],
-                                  "type" : "bytes32",
+                                  "type" : "bytes memory",
                                   "type_conversion" : false
                                 },
                                 "children" : 
@@ -1120,138 +1110,93 @@
                                       "argumentTypes" : 
                                       [
                                         {
-                                          "typeIdentifier" : "t_bytes_memory_ptr",
-                                          "typeString" : "bytes memory"
+                                          "typeIdentifier" : "t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
+                                          "typeString" : "literal_string \"Nu Token\""
                                         }
                                       ],
-                                      "overloadedDeclarations" : 
-                                      [
-                                        null
-                                      ],
-                                      "referencedDeclaration" : 81,
-                                      "type" : "function (bytes memory) pure returns (bytes32)",
-                                      "value" : "keccak256"
-                                    },
-                                    "id" : 62,
-                                    "name" : "Identifier",
-                                    "src" : "723:9:0"
-                                  },
-                                  {
-                                    "attributes" : 
-                                    {
-                                      "argumentTypes" : null,
                                       "isConstant" : false,
                                       "isLValue" : false,
                                       "isPure" : true,
-                                      "isStructConstructorCall" : false,
                                       "lValueRequested" : false,
-                                      "names" : 
-                                      [
-                                        null
-                                      ],
-                                      "type" : "bytes memory",
-                                      "type_conversion" : false
+                                      "member_name" : "encodePacked",
+                                      "referencedDeclaration" : null,
+                                      "type" : "function () pure returns (bytes memory)"
                                     },
                                     "children" : 
                                     [
                                       {
                                         "attributes" : 
                                         {
-                                          "argumentTypes" : 
-                                          [
-                                            {
-                                              "typeIdentifier" : "t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
-                                              "typeString" : "literal_string \"Nu Token\""
-                                            }
-                                          ],
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : true,
-                                          "lValueRequested" : false,
-                                          "member_name" : "encodePacked",
-                                          "referencedDeclaration" : null,
-                                          "type" : "function () pure returns (bytes memory)"
-                                        },
-                                        "children" : 
-                                        [
-                                          {
-                                            "attributes" : 
-                                            {
-                                              "argumentTypes" : null,
-                                              "overloadedDeclarations" : 
-                                              [
-                                                null
-                                              ],
-                                              "referencedDeclaration" : 74,
-                                              "type" : "abi",
-                                              "value" : "abi"
-                                            },
-                                            "id" : 63,
-                                            "name" : "Identifier",
-                                            "src" : "733:3:0"
-                                          }
-                                        ],
-                                        "id" : 64,
-                                        "name" : "MemberAccess",
-                                        "src" : "733:16:0"
-                                      },
-                                      {
-                                        "attributes" : 
-                                        {
                                           "argumentTypes" : null,
-                                          "hexvalue" : "4e7520546f6b656e",
-                                          "isConstant" : false,
-                                          "isLValue" : false,
-                                          "isPure" : true,
-                                          "lValueRequested" : false,
-                                          "subdenomination" : null,
-                                          "token" : "string",
-                                          "type" : "literal_string \"Nu Token\"",
-                                          "value" : "Nu Token"
+                                          "overloadedDeclarations" : 
+                                          [
+                                            null
+                                          ],
+                                          "referencedDeclaration" : 73,
+                                          "type" : "abi",
+                                          "value" : "abi"
                                         },
-                                        "id" : 65,
-                                        "name" : "Literal",
-                                        "src" : "750:10:0"
+                                        "id" : 63,
+                                        "name" : "Identifier",
+                                        "src" : "789:3:0"
                                       }
                                     ],
-                                    "id" : 66,
-                                    "name" : "FunctionCall",
-                                    "src" : "733:28:0"
+                                    "id" : 64,
+                                    "name" : "MemberAccess",
+                                    "src" : "789:16:0"
+                                  },
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "hexvalue" : "4e7520546f6b656e",
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : true,
+                                      "lValueRequested" : false,
+                                      "subdenomination" : null,
+                                      "token" : "string",
+                                      "type" : "literal_string \"Nu Token\"",
+                                      "value" : "Nu Token"
+                                    },
+                                    "id" : 65,
+                                    "name" : "Literal",
+                                    "src" : "806:10:0"
                                   }
                                 ],
-                                "id" : 67,
+                                "id" : 66,
                                 "name" : "FunctionCall",
-                                "src" : "723:39:0"
+                                "src" : "789:28:0"
                               }
                             ],
-                            "id" : 68,
-                            "name" : "TupleExpression",
-                            "src" : "722:41:0"
+                            "id" : 67,
+                            "name" : "FunctionCall",
+                            "src" : "779:39:0"
                           }
                         ],
-                        "id" : 69,
+                        "id" : 68,
                         "name" : "Return",
-                        "src" : "716:47:0"
+                        "src" : "772:46:0"
                       }
                     ],
-                    "id" : 70,
+                    "id" : 69,
                     "name" : "Block",
-                    "src" : "706:64:0"
+                    "src" : "762:63:0"
                   }
                 ],
-                "id" : 71,
+                "id" : 70,
                 "name" : "FunctionDefinition",
-                "src" : "656:114:0"
+                "src" : "711:114:0"
               }
             ],
-            "id" : 72,
+            "id" : 71,
             "name" : "ContractDefinition",
-            "src" : "637:135:0"
+            "src" : "692:135:0"
           }
         ],
-        "id" : 73,
+        "id" : 72,
         "name" : "SourceUnit",
-        "src" : "0:773:0"
+        "src" : "0:828:0"
       }
     }
   },

--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.json
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.json
@@ -3,15 +3,15 @@
   {
     "modifier_reentrancy/modifier_reentrancy.sol:Bank" : 
     {
-      "bin" : "6080604052348015600f57600080fd5b5060cb8061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000600160008190555060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820658c89e74be7111844c6e94d7cc01210ea45199e112a867038b8981a731010990029",
-      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000600160008190555060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820658c89e74be7111844c6e94d7cc01210ea45199e112a867038b8981a731010990029",
-      "srcmap" : "637:178:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:178:0;;;;;;;",
-      "srcmap-runtime" : "637:178:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:178:0;;;;;;;;;;;;;;;;;;;676:137;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;718:7;748:1;736:9;:13;;;;776:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;776:28:0;;;766:39;;;;;;759:47;;676:137;:::o"
+      "bin" : "6080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a723058205a56a5f23b6b3f606d0d5d74f269aeb0e536c958929f934b6107e315b73324390029",
+      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a723058205a56a5f23b6b3f606d0d5d74f269aeb0e536c958929f934b6107e315b73324390029",
+      "srcmap" : "637:135:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:135:0;;;;;;;",
+      "srcmap-runtime" : "637:135:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;637:135:0;;;;;;;;;;;;;;;;;;;656:114;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;698:7;733:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;733:28:0;;;723:39;;;;;;716:47;;656:114;:::o"
     },
     "modifier_reentrancy/modifier_reentrancy.sol:ModifierEntrancy" : 
     {
-      "bin" : "608060405234801561001057600080fd5b5061024f806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561013057600080fd5b505af1158015610144573d6000803e3d6000fd5b505050506040513d602081101561015a57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820795f77e4ec5e578326ae1ce09fab76aa1e3ab6c7f7e8a2a25cdca38095844eb20029",
-      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561013057600080fd5b505af1158015610144573d6000803e3d6000fd5b505050506040513d602081101561015a57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820795f77e4ec5e578326ae1ce09fab76aa1e3ab6c7f7e8a2a25cdca38095844eb20029",
+      "bin" : "608060405234801561001057600080fd5b5061024f806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561013057600080fd5b505af1158015610144573d6000803e3d6000fd5b505050506040513d602081101561015a57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820524c21dfec95455436bf89f8c21b317442716a28516bfa88b5d64a83b988ff920029",
+      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146100e857600080fd5b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561013057600080fd5b505af1158015610144573d6000803e3d6000fd5b505050506040513d602081101561015a57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e000000000000000000000000000000000000000000000000815250600801905060405160208183030381529060405280519060200120146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a72305820524c21dfec95455436bf89f8c21b317442716a28516bfa88b5d64a83b988ff920029",
       "srcmap" : "25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;",
       "srcmap-runtime" : "25:610:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:610:0;;;;;;;;;;;;;;;;;;;;;;;;223:94;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;223:94;617:1;589:12;:24;602:10;589:24;;;;;;;;;;;;;;;;:29;581:38;;;;;;462:10;457:30;;;:32;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;457:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;457:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;457:32:0;;;;;;;;;;;;;;;;424:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;424:28:0;;;414:39;;;;;;:75;406:84;;;;;;310:2;282:12;:24;295:10;282:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;223:94::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
     }
@@ -33,7 +33,7 @@
           {
             "Bank" : 
             [
-              78
+              72
             ],
             "ModifierEntrancy" : 
             [
@@ -77,7 +77,7 @@
                 57
               ],
               "name" : "ModifierEntrancy",
-              "scope" : 79
+              "scope" : 73
             },
             "children" : 
             [
@@ -344,7 +344,7 @@
                                           [
                                             null
                                           ],
-                                          "referencedDeclaration" : 93,
+                                          "referencedDeclaration" : 87,
                                           "type" : "msg",
                                           "value" : "msg"
                                         },
@@ -458,10 +458,10 @@
                                   ],
                                   "overloadedDeclarations" : 
                                   [
-                                    96,
-                                    97
+                                    90,
+                                    91
                                   ],
-                                  "referencedDeclaration" : 96,
+                                  "referencedDeclaration" : 90,
                                   "type" : "function (bool) pure",
                                   "value" : "require"
                                 },
@@ -519,7 +519,7 @@
                                           [
                                             null
                                           ],
-                                          "referencedDeclaration" : 87,
+                                          "referencedDeclaration" : 81,
                                           "type" : "function (bytes memory) pure returns (bytes32)",
                                           "value" : "keccak256"
                                         },
@@ -573,7 +573,7 @@
                                                   [
                                                     null
                                                   ],
-                                                  "referencedDeclaration" : 80,
+                                                  "referencedDeclaration" : 74,
                                                   "type" : "abi",
                                                   "value" : "abi"
                                                 },
@@ -648,7 +648,7 @@
                                           "isPure" : false,
                                           "lValueRequested" : false,
                                           "member_name" : "supportsToken",
-                                          "referencedDeclaration" : 77,
+                                          "referencedDeclaration" : 71,
                                           "type" : "function () external returns (bytes32)"
                                         },
                                         "children" : 
@@ -685,7 +685,7 @@
                                                   [
                                                     null
                                                   ],
-                                                  "referencedDeclaration" : 78,
+                                                  "referencedDeclaration" : 72,
                                                   "type" : "type(contract Bank)",
                                                   "value" : "Bank"
                                                 },
@@ -715,7 +715,7 @@
                                                       [
                                                         null
                                                       ],
-                                                      "referencedDeclaration" : 93,
+                                                      "referencedDeclaration" : 87,
                                                       "type" : "msg",
                                                       "value" : "msg"
                                                     },
@@ -831,10 +831,10 @@
                                   ],
                                   "overloadedDeclarations" : 
                                   [
-                                    96,
-                                    97
+                                    90,
+                                    91
                                   ],
-                                  "referencedDeclaration" : 96,
+                                  "referencedDeclaration" : 90,
                                   "type" : "function (bool) pure",
                                   "value" : "require"
                                 },
@@ -910,7 +910,7 @@
                                               [
                                                 null
                                               ],
-                                              "referencedDeclaration" : 93,
+                                              "referencedDeclaration" : 87,
                                               "type" : "msg",
                                               "value" : "msg"
                                             },
@@ -997,42 +997,13 @@
               "fullyImplemented" : true,
               "linearizedBaseContracts" : 
               [
-                78
+                72
               ],
               "name" : "Bank",
-              "scope" : 79
+              "scope" : 73
             },
             "children" : 
             [
-              {
-                "attributes" : 
-                {
-                  "constant" : false,
-                  "name" : "state_var",
-                  "scope" : 78,
-                  "stateVariable" : true,
-                  "storageLocation" : "default",
-                  "type" : "uint256",
-                  "value" : null,
-                  "visibility" : "internal"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "name" : "uint",
-                      "type" : "uint256"
-                    },
-                    "id" : 58,
-                    "name" : "ElementaryTypeName",
-                    "src" : "656:4:0"
-                  }
-                ],
-                "id" : 59,
-                "name" : "VariableDeclaration",
-                "src" : "656:14:0"
-              },
               {
                 "attributes" : 
                 {
@@ -1045,7 +1016,7 @@
                     null
                   ],
                   "name" : "supportsToken",
-                  "scope" : 78,
+                  "scope" : 72,
                   "stateMutability" : "nonpayable",
                   "superFunction" : null,
                   "visibility" : "external"
@@ -1061,9 +1032,9 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 60,
+                    "id" : 58,
                     "name" : "ParameterList",
-                    "src" : "698:2:0"
+                    "src" : "678:2:0"
                   },
                   {
                     "children" : 
@@ -1073,7 +1044,7 @@
                         {
                           "constant" : false,
                           "name" : "",
-                          "scope" : 77,
+                          "scope" : 71,
                           "stateVariable" : false,
                           "storageLocation" : "default",
                           "type" : "bytes32",
@@ -1088,87 +1059,27 @@
                               "name" : "bytes32",
                               "type" : "bytes32"
                             },
-                            "id" : 61,
+                            "id" : 59,
                             "name" : "ElementaryTypeName",
-                            "src" : "718:7:0"
+                            "src" : "698:7:0"
                           }
                         ],
-                        "id" : 62,
+                        "id" : 60,
                         "name" : "VariableDeclaration",
-                        "src" : "718:7:0"
+                        "src" : "698:7:0"
                       }
                     ],
-                    "id" : 63,
+                    "id" : 61,
                     "name" : "ParameterList",
-                    "src" : "717:9:0"
+                    "src" : "697:9:0"
                   },
                   {
                     "children" : 
                     [
                       {
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "isConstant" : false,
-                              "isLValue" : false,
-                              "isPure" : false,
-                              "lValueRequested" : false,
-                              "operator" : "=",
-                              "type" : "uint256"
-                            },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "overloadedDeclarations" : 
-                                  [
-                                    null
-                                  ],
-                                  "referencedDeclaration" : 59,
-                                  "type" : "uint256",
-                                  "value" : "state_var"
-                                },
-                                "id" : 64,
-                                "name" : "Identifier",
-                                "src" : "736:9:0"
-                              },
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "hexvalue" : "31",
-                                  "isConstant" : false,
-                                  "isLValue" : false,
-                                  "isPure" : true,
-                                  "lValueRequested" : false,
-                                  "subdenomination" : null,
-                                  "token" : "number",
-                                  "type" : "int_const 1",
-                                  "value" : "1"
-                                },
-                                "id" : 65,
-                                "name" : "Literal",
-                                "src" : "748:1:0"
-                              }
-                            ],
-                            "id" : 66,
-                            "name" : "Assignment",
-                            "src" : "736:13:0"
-                          }
-                        ],
-                        "id" : 67,
-                        "name" : "ExpressionStatement",
-                        "src" : "736:13:0"
-                      },
-                      {
                         "attributes" : 
                         {
-                          "functionReturnParameters" : 63
+                          "functionReturnParameters" : 61
                         },
                         "children" : 
                         [
@@ -1217,13 +1128,13 @@
                                       [
                                         null
                                       ],
-                                      "referencedDeclaration" : 87,
+                                      "referencedDeclaration" : 81,
                                       "type" : "function (bytes memory) pure returns (bytes32)",
                                       "value" : "keccak256"
                                     },
-                                    "id" : 68,
+                                    "id" : 62,
                                     "name" : "Identifier",
-                                    "src" : "766:9:0"
+                                    "src" : "723:9:0"
                                   },
                                   {
                                     "attributes" : 
@@ -1271,18 +1182,18 @@
                                               [
                                                 null
                                               ],
-                                              "referencedDeclaration" : 80,
+                                              "referencedDeclaration" : 74,
                                               "type" : "abi",
                                               "value" : "abi"
                                             },
-                                            "id" : 69,
+                                            "id" : 63,
                                             "name" : "Identifier",
-                                            "src" : "776:3:0"
+                                            "src" : "733:3:0"
                                           }
                                         ],
-                                        "id" : 70,
+                                        "id" : 64,
                                         "name" : "MemberAccess",
-                                        "src" : "776:16:0"
+                                        "src" : "733:16:0"
                                       },
                                       {
                                         "attributes" : 
@@ -1298,49 +1209,49 @@
                                           "type" : "literal_string \"Nu Token\"",
                                           "value" : "Nu Token"
                                         },
-                                        "id" : 71,
+                                        "id" : 65,
                                         "name" : "Literal",
-                                        "src" : "793:10:0"
+                                        "src" : "750:10:0"
                                       }
                                     ],
-                                    "id" : 72,
+                                    "id" : 66,
                                     "name" : "FunctionCall",
-                                    "src" : "776:28:0"
+                                    "src" : "733:28:0"
                                   }
                                 ],
-                                "id" : 73,
+                                "id" : 67,
                                 "name" : "FunctionCall",
-                                "src" : "766:39:0"
+                                "src" : "723:39:0"
                               }
                             ],
-                            "id" : 74,
+                            "id" : 68,
                             "name" : "TupleExpression",
-                            "src" : "765:41:0"
+                            "src" : "722:41:0"
                           }
                         ],
-                        "id" : 75,
+                        "id" : 69,
                         "name" : "Return",
-                        "src" : "759:47:0"
+                        "src" : "716:47:0"
                       }
                     ],
-                    "id" : 76,
+                    "id" : 70,
                     "name" : "Block",
-                    "src" : "726:87:0"
+                    "src" : "706:64:0"
                   }
                 ],
-                "id" : 77,
+                "id" : 71,
                 "name" : "FunctionDefinition",
-                "src" : "676:137:0"
+                "src" : "656:114:0"
               }
             ],
-            "id" : 78,
+            "id" : 72,
             "name" : "ContractDefinition",
-            "src" : "637:178:0"
+            "src" : "637:135:0"
           }
         ],
-        "id" : 79,
+        "id" : 73,
         "name" : "SourceUnit",
-        "src" : "0:816:0"
+        "src" : "0:773:0"
       }
     }
   },

--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
@@ -1,9 +1,11 @@
 pragma solidity ^0.5.0;
 
 contract ModifierEntrancy {
+
   mapping (address => uint) public tokenBalance;
   string constant name = "Nu Token";
   Bank bank;
+  
   constructor() public{
       bank = new Bank();
   }
@@ -12,20 +14,24 @@ contract ModifierEntrancy {
   function airDrop() hasNoBalance supportsToken  public{
     tokenBalance[msg.sender] += 20;
   }
+  
   //Checks that the contract responds the way we want
   modifier supportsToken() {
     require(keccak256(abi.encodePacked("Nu Token")) == bank.supportsToken());
     _;
   }
+  
   //Checks that the caller has a zero balance
   modifier hasNoBalance {
-      //require(tokenBalance[msg.sender] == 0);
+      require(tokenBalance[msg.sender] == 0);
       _;
   }
 }
 
 contract Bank{
+
     function supportsToken() external returns(bytes32) {
         return keccak256(abi.encodePacked("Nu Token"));
     }
+
 }

--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
@@ -22,7 +22,9 @@ contract ModifierEntrancy {
 }
 
 contract Bank{
-    function supportsToken() external pure returns(bytes32){
+    uint state_var;
+    function supportsToken() external returns(bytes32){
+        state_var = 1;
         return(keccak256(abi.encodePacked("Nu Token")));
     }
 }

--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
@@ -3,26 +3,29 @@ pragma solidity ^0.5.0;
 contract ModifierEntrancy {
   mapping (address => uint) public tokenBalance;
   string constant name = "Nu Token";
+  Bank bank;
+  constructor() public{
+      bank = new Bank();
+  }
 
   //If a contract has a zero balance and supports the token give them some token
   function airDrop() hasNoBalance supportsToken  public{
     tokenBalance[msg.sender] += 20;
   }
-
   //Checks that the contract responds the way we want
   modifier supportsToken() {
-    require(keccak256(abi.encodePacked("Nu Token")) == Bank(msg.sender).supportsToken());
+    require(keccak256(abi.encodePacked("Nu Token")) == bank.supportsToken());
     _;
   }
   //Checks that the caller has a zero balance
   modifier hasNoBalance {
-      require(tokenBalance[msg.sender] == 0);
+      //require(tokenBalance[msg.sender] == 0);
       _;
   }
 }
 
 contract Bank{
-    function supportsToken() external returns(bytes32){
-        return(keccak256(abi.encodePacked("Nu Token")));
+    function supportsToken() external returns(bytes32) {
+        return keccak256(abi.encodePacked("Nu Token"));
     }
 }

--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.sol
@@ -22,9 +22,7 @@ contract ModifierEntrancy {
 }
 
 contract Bank{
-    uint state_var;
     function supportsToken() external returns(bytes32){
-        state_var = 1;
         return(keccak256(abi.encodePacked("Nu Token")));
     }
 }

--- a/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.yaml
+++ b/test_cases/solidity/reentracy/modifier_reentrancy/modifier_reentrancy.yaml
@@ -5,4 +5,4 @@ issues:
   locations:
   - bytecode_offsets: {}
     line_numbers:
-      modifier_reentrancy.sol: [8, 9]
+      modifier_reentrancy.sol: [12, 13]

--- a/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.json
+++ b/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.json
@@ -1,1108 +1,1348 @@
-{  
-    "contracts":{  
-        "modifier_reentrancy_fixed.sol:ModifierEntrancy":{  
-           "bin":"608060405234801561001057600080fd5b5061024d806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610209565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b815260040160206040518083038186803b1580156100e357600080fd5b505afa1580156100f7573d6000803e3d6000fd5b505050506040513d602081101561010d57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461016f57600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101ba57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208a879dbdedf38235b553f7465866093e6e0307d744f8643132c64a07743201bc0029",
-           "bin-runtime":"608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610209565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b815260040160206040518083038186803b1580156100e357600080fd5b505afa1580156100f7573d6000803e3d6000fd5b505050506040513d602081101561010d57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461016f57600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101ba57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208a879dbdedf38235b553f7465866093e6e0307d744f8643132c64a07743201bc0029",
-           "srcmap":"25:674:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:674:0;;;;;;;",
-           "srcmap-runtime":"25:674:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:674:0;;;;;;;;;;;;;;;;;;;;;;;;223:158;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;223:158;526:10;521:30;;;:32;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;521:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;521:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;521:32:0;;;;;;;;;;;;;;;;488:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;488:28:0;;;478:39;;;;;;:75;470:84;;;;;;681:1;653:12;:24;666:10;653:24;;;;;;;;;;;;;;;;:29;645:38;;;;;;374:2;346:12;:24;359:10;346:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;223:158::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
-        },
-       "modifier_reentrancy_fixed.sol:Bank":{  
-          "bin":"6080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820fd70cc055b2a085075cde8aabc5b262e4b30ba6d70fabcfc6bc60a4af5e9f3620029",
-          "bin-runtime":"6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820fd70cc055b2a085075cde8aabc5b262e4b30ba6d70fabcfc6bc60a4af5e9f3620029",
-          "srcmap":"701:140:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:140:0;;;;;;;",
-          "srcmap-runtime":"701:140:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:140:0;;;;;;;;;;;;;;;;;;;720:119;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;767:7;802:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;802:28:0;;;792:39;;;;;;785:47;;720:119;:::o"
-       }
+{
+  "contracts" : 
+  {
+    "modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol:Bank" : 
+    {
+      "bin" : "6080604052348015600f57600080fd5b5060cb8061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000600160008190555060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820842f30d24bfb641a95748ca265af0de36b02b8239b5089b8adce1e4a250919ed0029",
+      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000600160008190555060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820842f30d24bfb641a95748ca265af0de36b02b8239b5089b8adce1e4a250919ed0029",
+      "srcmap" : "701:178:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:178:0;;;;;;;",
+      "srcmap-runtime" : "701:178:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:178:0;;;;;;;;;;;;;;;;;;;740:137;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;782:7;812:1;800:9;:13;;;;840:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;840:28:0;;;830:39;;;;;;823:47;;740:137;:::o"
     },
-    "sourceList":[  
-       "modifier_reentrancy_fixed.sol"
-    ],
-    "sources":{  
-       "modifier_reentrancy_fixed.sol":{  
-          "AST":{  
-             "attributes":{  
-                "absolutePath":"modifier_reentrancy_fixed.sol",
-                "exportedSymbols":{  
-                   "Bank":[  
-                      72
-                   ],
-                   "ModifierEntrancy":[  
-                      57
-                   ]
-                }
-             },
-             "children":[  
-                {  
-                   "attributes":{  
-                      "literals":[  
-                         "solidity",
-                         "^",
-                         "0.5",
-                         ".0"
-                      ]
-                   },
-                   "id":1,
-                   "name":"PragmaDirective",
-                   "src":"0:23:0"
-                },
-                {  
-                   "attributes":{  
-                      "baseContracts":[  
-                         null
-                      ],
-                      "contractDependencies":[  
-                         null
-                      ],
-                      "contractKind":"contract",
-                      "documentation":null,
-                      "fullyImplemented":true,
-                      "linearizedBaseContracts":[  
-                         57
-                      ],
-                      "name":"ModifierEntrancy",
-                      "scope":73
-                   },
-                   "children":[  
-                      {  
-                         "attributes":{  
-                            "constant":false,
-                            "name":"tokenBalance",
-                            "scope":57,
-                            "stateVariable":true,
-                            "storageLocation":"default",
-                            "type":"mapping(address => uint256)",
-                            "value":null,
-                            "visibility":"public"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "type":"mapping(address => uint256)"
-                               },
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "name":"address",
-                                        "type":"address"
-                                     },
-                                     "id":2,
-                                     "name":"ElementaryTypeName",
-                                     "src":"64:7:0"
-                                  },
-                                  {  
-                                     "attributes":{  
-                                        "name":"uint",
-                                        "type":"uint256"
-                                     },
-                                     "id":3,
-                                     "name":"ElementaryTypeName",
-                                     "src":"75:4:0"
-                                  }
-                               ],
-                               "id":4,
-                               "name":"Mapping",
-                               "src":"55:25:0"
-                            }
-                         ],
-                         "id":5,
-                         "name":"VariableDeclaration",
-                         "src":"55:45:0"
-                      },
-                      {  
-                         "attributes":{  
-                            "constant":true,
-                            "name":"name",
-                            "scope":57,
-                            "stateVariable":true,
-                            "storageLocation":"default",
-                            "type":"string",
-                            "visibility":"internal"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "name":"string",
-                                  "type":"string"
-                               },
-                               "id":6,
-                               "name":"ElementaryTypeName",
-                               "src":"104:6:0"
-                            },
-                            {  
-                               "attributes":{  
-                                  "argumentTypes":null,
-                                  "hexvalue":"4e7520546f6b656e",
-                                  "isConstant":false,
-                                  "isLValue":false,
-                                  "isPure":true,
-                                  "lValueRequested":false,
-                                  "subdenomination":null,
-                                  "token":"string",
-                                  "type":"literal_string \"Nu Token\"",
-                                  "value":"Nu Token"
-                               },
-                               "id":7,
-                               "name":"Literal",
-                               "src":"127:10:0"
-                            }
-                         ],
-                         "id":8,
-                         "name":"VariableDeclaration",
-                         "src":"104:33:0"
-                      },
-                      {  
-                         "attributes":{  
-                            "documentation":null,
-                            "implemented":true,
-                            "isConstructor":false,
-                            "kind":"function",
-                            "name":"airDrop",
-                            "scope":57,
-                            "stateMutability":"nonpayable",
-                            "superFunction":null,
-                            "visibility":"public"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":9,
-                               "name":"ParameterList",
-                               "src":"239:2:0"
-                            },
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":14,
-                               "name":"ParameterList",
-                               "src":"276:0:0"
-                            },
-                            {  
-                               "attributes":{  
-                                  "arguments":null
-                               },
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "argumentTypes":null,
-                                        "overloadedDeclarations":[  
-                                           null
-                                        ],
-                                        "referencedDeclaration":43,
-                                        "type":"modifier ()",
-                                        "value":"supportsToken"
-                                     },
-                                     "id":10,
-                                     "name":"Identifier",
-                                     "src":"242:13:0"
-                                  }
-                               ],
-                               "id":11,
-                               "name":"ModifierInvocation",
-                               "src":"242:13:0"
-                            },
-                            {  
-                               "attributes":{  
-                                  "arguments":null
-                               },
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "argumentTypes":null,
-                                        "overloadedDeclarations":[  
-                                           null
-                                        ],
-                                        "referencedDeclaration":56,
-                                        "type":"modifier ()",
-                                        "value":"hasNoBalance"
-                                     },
-                                     "id":12,
-                                     "name":"Identifier",
-                                     "src":"256:12:0"
-                                  }
-                               ],
-                               "id":13,
-                               "name":"ModifierInvocation",
-                               "src":"256:12:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "argumentTypes":null,
-                                              "isConstant":false,
-                                              "isLValue":false,
-                                              "isPure":false,
-                                              "lValueRequested":false,
-                                              "operator":"+=",
-                                              "type":"uint256"
-                                           },
-                                           "children":[  
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "isConstant":false,
-                                                    "isLValue":true,
-                                                    "isPure":false,
-                                                    "lValueRequested":true,
-                                                    "type":"uint256"
-                                                 },
-                                                 "children":[  
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "overloadedDeclarations":[  
-                                                             null
-                                                          ],
-                                                          "referencedDeclaration":5,
-                                                          "type":"mapping(address => uint256)",
-                                                          "value":"tokenBalance"
-                                                       },
-                                                       "id":15,
-                                                       "name":"Identifier",
-                                                       "src":"346:12:0"
-                                                    },
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":false,
-                                                          "lValueRequested":false,
-                                                          "member_name":"sender",
-                                                          "referencedDeclaration":null,
-                                                          "type":"address payable"
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "overloadedDeclarations":[  
-                                                                   null
-                                                                ],
-                                                                "referencedDeclaration":87,
-                                                                "type":"msg",
-                                                                "value":"msg"
-                                                             },
-                                                             "id":16,
-                                                             "name":"Identifier",
-                                                             "src":"359:3:0"
-                                                          }
-                                                       ],
-                                                       "id":17,
-                                                       "name":"MemberAccess",
-                                                       "src":"359:10:0"
-                                                    }
-                                                 ],
-                                                 "id":18,
-                                                 "name":"IndexAccess",
-                                                 "src":"346:24:0"
-                                              },
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "hexvalue":"3230",
-                                                    "isConstant":false,
-                                                    "isLValue":false,
-                                                    "isPure":true,
-                                                    "lValueRequested":false,
-                                                    "subdenomination":null,
-                                                    "token":"number",
-                                                    "type":"int_const 20",
-                                                    "value":"20"
-                                                 },
-                                                 "id":19,
-                                                 "name":"Literal",
-                                                 "src":"374:2:0"
-                                              }
-                                           ],
-                                           "id":20,
-                                           "name":"Assignment",
-                                           "src":"346:30:0"
-                                        }
-                                     ],
-                                     "id":21,
-                                     "name":"ExpressionStatement",
-                                     "src":"346:30:0"
-                                  }
-                               ],
-                               "id":22,
-                               "name":"Block",
-                               "src":"276:105:0"
-                            }
-                         ],
-                         "id":23,
-                         "name":"FunctionDefinition",
-                         "src":"223:158:0"
-                      },
-                      {  
-                         "attributes":{  
-                            "documentation":null,
-                            "name":"supportsToken",
-                            "visibility":"internal"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":24,
-                               "name":"ParameterList",
-                               "src":"461:2:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "argumentTypes":null,
-                                              "isConstant":false,
-                                              "isLValue":false,
-                                              "isPure":false,
-                                              "isStructConstructorCall":false,
-                                              "lValueRequested":false,
-                                              "names":[  
-                                                 null
-                                              ],
-                                              "type":"tuple()",
-                                              "type_conversion":false
-                                           },
-                                           "children":[  
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":[  
-                                                       {  
-                                                          "typeIdentifier":"t_bool",
-                                                          "typeString":"bool"
-                                                       }
-                                                    ],
-                                                    "overloadedDeclarations":[  
-                                                       90,
-                                                       91
-                                                    ],
-                                                    "referencedDeclaration":90,
-                                                    "type":"function (bool) pure",
-                                                    "value":"require"
-                                                 },
-                                                 "id":25,
-                                                 "name":"Identifier",
-                                                 "src":"470:7:0"
-                                              },
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "commonType":{  
-                                                       "typeIdentifier":"t_bytes32",
-                                                       "typeString":"bytes32"
-                                                    },
-                                                    "isConstant":false,
-                                                    "isLValue":false,
-                                                    "isPure":false,
-                                                    "lValueRequested":false,
-                                                    "operator":"==",
-                                                    "type":"bool"
-                                                 },
-                                                 "children":[  
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":true,
-                                                          "isStructConstructorCall":false,
-                                                          "lValueRequested":false,
-                                                          "names":[  
-                                                             null
-                                                          ],
-                                                          "type":"bytes32",
-                                                          "type_conversion":false
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":[  
-                                                                   {  
-                                                                      "typeIdentifier":"t_bytes_memory_ptr",
-                                                                      "typeString":"bytes memory"
-                                                                   }
-                                                                ],
-                                                                "overloadedDeclarations":[  
-                                                                   null
-                                                                ],
-                                                                "referencedDeclaration":81,
-                                                                "type":"function (bytes memory) pure returns (bytes32)",
-                                                                "value":"keccak256"
-                                                             },
-                                                             "id":26,
-                                                             "name":"Identifier",
-                                                             "src":"478:9:0"
-                                                          },
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":true,
-                                                                "isStructConstructorCall":false,
-                                                                "lValueRequested":false,
-                                                                "names":[  
-                                                                   null
-                                                                ],
-                                                                "type":"bytes memory",
-                                                                "type_conversion":false
-                                                             },
-                                                             "children":[  
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":[  
-                                                                         {  
-                                                                            "typeIdentifier":"t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
-                                                                            "typeString":"literal_string \"Nu Token\""
-                                                                         }
-                                                                      ],
-                                                                      "isConstant":false,
-                                                                      "isLValue":false,
-                                                                      "isPure":true,
-                                                                      "lValueRequested":false,
-                                                                      "member_name":"encodePacked",
-                                                                      "referencedDeclaration":null,
-                                                                      "type":"function () pure returns (bytes memory)"
-                                                                   },
-                                                                   "children":[  
-                                                                      {  
-                                                                         "attributes":{  
-                                                                            "argumentTypes":null,
-                                                                            "overloadedDeclarations":[  
-                                                                               null
-                                                                            ],
-                                                                            "referencedDeclaration":74,
-                                                                            "type":"abi",
-                                                                            "value":"abi"
-                                                                         },
-                                                                         "id":27,
-                                                                         "name":"Identifier",
-                                                                         "src":"488:3:0"
-                                                                      }
-                                                                   ],
-                                                                   "id":28,
-                                                                   "name":"MemberAccess",
-                                                                   "src":"488:16:0"
-                                                                },
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":null,
-                                                                      "hexvalue":"4e7520546f6b656e",
-                                                                      "isConstant":false,
-                                                                      "isLValue":false,
-                                                                      "isPure":true,
-                                                                      "lValueRequested":false,
-                                                                      "subdenomination":null,
-                                                                      "token":"string",
-                                                                      "type":"literal_string \"Nu Token\"",
-                                                                      "value":"Nu Token"
-                                                                   },
-                                                                   "id":29,
-                                                                   "name":"Literal",
-                                                                   "src":"505:10:0"
-                                                                }
-                                                             ],
-                                                             "id":30,
-                                                             "name":"FunctionCall",
-                                                             "src":"488:28:0"
-                                                          }
-                                                       ],
-                                                       "id":31,
-                                                       "name":"FunctionCall",
-                                                       "src":"478:39:0"
-                                                    },
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "arguments":[  
-                                                             null
-                                                          ],
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":false,
-                                                          "isStructConstructorCall":false,
-                                                          "lValueRequested":false,
-                                                          "names":[  
-                                                             null
-                                                          ],
-                                                          "type":"bytes32",
-                                                          "type_conversion":false
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":[  
-                                                                   null
-                                                                ],
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":false,
-                                                                "lValueRequested":false,
-                                                                "member_name":"supportsToken",
-                                                                "referencedDeclaration":71,
-                                                                "type":"function () pure external returns (bytes32)"
-                                                             },
-                                                             "children":[  
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":null,
-                                                                      "isConstant":false,
-                                                                      "isLValue":false,
-                                                                      "isPure":false,
-                                                                      "isStructConstructorCall":false,
-                                                                      "lValueRequested":false,
-                                                                      "names":[  
-                                                                         null
-                                                                      ],
-                                                                      "type":"contract Bank",
-                                                                      "type_conversion":true
-                                                                   },
-                                                                   "children":[  
-                                                                      {  
-                                                                         "attributes":{  
-                                                                            "argumentTypes":[  
-                                                                               {  
-                                                                                  "typeIdentifier":"t_address_payable",
-                                                                                  "typeString":"address payable"
-                                                                               }
-                                                                            ],
-                                                                            "overloadedDeclarations":[  
-                                                                               null
-                                                                            ],
-                                                                            "referencedDeclaration":72,
-                                                                            "type":"type(contract Bank)",
-                                                                            "value":"Bank"
-                                                                         },
-                                                                         "id":32,
-                                                                         "name":"Identifier",
-                                                                         "src":"521:4:0"
-                                                                      },
-                                                                      {  
-                                                                         "attributes":{  
-                                                                            "argumentTypes":null,
-                                                                            "isConstant":false,
-                                                                            "isLValue":false,
-                                                                            "isPure":false,
-                                                                            "lValueRequested":false,
-                                                                            "member_name":"sender",
-                                                                            "referencedDeclaration":null,
-                                                                            "type":"address payable"
-                                                                         },
-                                                                         "children":[  
-                                                                            {  
-                                                                               "attributes":{  
-                                                                                  "argumentTypes":null,
-                                                                                  "overloadedDeclarations":[  
-                                                                                     null
-                                                                                  ],
-                                                                                  "referencedDeclaration":87,
-                                                                                  "type":"msg",
-                                                                                  "value":"msg"
-                                                                               },
-                                                                               "id":33,
-                                                                               "name":"Identifier",
-                                                                               "src":"526:3:0"
-                                                                            }
-                                                                         ],
-                                                                         "id":34,
-                                                                         "name":"MemberAccess",
-                                                                         "src":"526:10:0"
-                                                                      }
-                                                                   ],
-                                                                   "id":35,
-                                                                   "name":"FunctionCall",
-                                                                   "src":"521:16:0"
-                                                                }
-                                                             ],
-                                                             "id":36,
-                                                             "name":"MemberAccess",
-                                                             "src":"521:30:0"
-                                                          }
-                                                       ],
-                                                       "id":37,
-                                                       "name":"FunctionCall",
-                                                       "src":"521:32:0"
-                                                    }
-                                                 ],
-                                                 "id":38,
-                                                 "name":"BinaryOperation",
-                                                 "src":"478:75:0"
-                                              }
-                                           ],
-                                           "id":39,
-                                           "name":"FunctionCall",
-                                           "src":"470:84:0"
-                                        }
-                                     ],
-                                     "id":40,
-                                     "name":"ExpressionStatement",
-                                     "src":"470:84:0"
-                                  },
-                                  {  
-                                     "id":41,
-                                     "name":"PlaceholderStatement",
-                                     "src":"560:1:0"
-                                  }
-                               ],
-                               "id":42,
-                               "name":"Block",
-                               "src":"464:102:0"
-                            }
-                         ],
-                         "id":43,
-                         "name":"ModifierDefinition",
-                         "src":"439:127:0"
-                      },
-                      {  
-                         "attributes":{  
-                            "documentation":null,
-                            "name":"hasNoBalance",
-                            "visibility":"internal"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":44,
-                               "name":"ParameterList",
-                               "src":"637:0:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "argumentTypes":null,
-                                              "isConstant":false,
-                                              "isLValue":false,
-                                              "isPure":false,
-                                              "isStructConstructorCall":false,
-                                              "lValueRequested":false,
-                                              "names":[  
-                                                 null
-                                              ],
-                                              "type":"tuple()",
-                                              "type_conversion":false
-                                           },
-                                           "children":[  
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":[  
-                                                       {  
-                                                          "typeIdentifier":"t_bool",
-                                                          "typeString":"bool"
-                                                       }
-                                                    ],
-                                                    "overloadedDeclarations":[  
-                                                       90,
-                                                       91
-                                                    ],
-                                                    "referencedDeclaration":90,
-                                                    "type":"function (bool) pure",
-                                                    "value":"require"
-                                                 },
-                                                 "id":45,
-                                                 "name":"Identifier",
-                                                 "src":"645:7:0"
-                                              },
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "commonType":{  
-                                                       "typeIdentifier":"t_uint256",
-                                                       "typeString":"uint256"
-                                                    },
-                                                    "isConstant":false,
-                                                    "isLValue":false,
-                                                    "isPure":false,
-                                                    "lValueRequested":false,
-                                                    "operator":"==",
-                                                    "type":"bool"
-                                                 },
-                                                 "children":[  
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "isConstant":false,
-                                                          "isLValue":true,
-                                                          "isPure":false,
-                                                          "lValueRequested":false,
-                                                          "type":"uint256"
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "overloadedDeclarations":[  
-                                                                   null
-                                                                ],
-                                                                "referencedDeclaration":5,
-                                                                "type":"mapping(address => uint256)",
-                                                                "value":"tokenBalance"
-                                                             },
-                                                             "id":46,
-                                                             "name":"Identifier",
-                                                             "src":"653:12:0"
-                                                          },
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":false,
-                                                                "lValueRequested":false,
-                                                                "member_name":"sender",
-                                                                "referencedDeclaration":null,
-                                                                "type":"address payable"
-                                                             },
-                                                             "children":[  
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":null,
-                                                                      "overloadedDeclarations":[  
-                                                                         null
-                                                                      ],
-                                                                      "referencedDeclaration":87,
-                                                                      "type":"msg",
-                                                                      "value":"msg"
-                                                                   },
-                                                                   "id":47,
-                                                                   "name":"Identifier",
-                                                                   "src":"666:3:0"
-                                                                }
-                                                             ],
-                                                             "id":48,
-                                                             "name":"MemberAccess",
-                                                             "src":"666:10:0"
-                                                          }
-                                                       ],
-                                                       "id":49,
-                                                       "name":"IndexAccess",
-                                                       "src":"653:24:0"
-                                                    },
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "hexvalue":"30",
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":true,
-                                                          "lValueRequested":false,
-                                                          "subdenomination":null,
-                                                          "token":"number",
-                                                          "type":"int_const 0",
-                                                          "value":"0"
-                                                       },
-                                                       "id":50,
-                                                       "name":"Literal",
-                                                       "src":"681:1:0"
-                                                    }
-                                                 ],
-                                                 "id":51,
-                                                 "name":"BinaryOperation",
-                                                 "src":"653:29:0"
-                                              }
-                                           ],
-                                           "id":52,
-                                           "name":"FunctionCall",
-                                           "src":"645:38:0"
-                                        }
-                                     ],
-                                     "id":53,
-                                     "name":"ExpressionStatement",
-                                     "src":"645:38:0"
-                                  },
-                                  {  
-                                     "id":54,
-                                     "name":"PlaceholderStatement",
-                                     "src":"691:1:0"
-                                  }
-                               ],
-                               "id":55,
-                               "name":"Block",
-                               "src":"637:60:0"
-                            }
-                         ],
-                         "id":56,
-                         "name":"ModifierDefinition",
-                         "src":"615:82:0"
-                      }
-                   ],
-                   "id":57,
-                   "name":"ContractDefinition",
-                   "src":"25:674:0"
-                },
-                {  
-                   "attributes":{  
-                      "baseContracts":[  
-                         null
-                      ],
-                      "contractDependencies":[  
-                         null
-                      ],
-                      "contractKind":"contract",
-                      "documentation":null,
-                      "fullyImplemented":true,
-                      "linearizedBaseContracts":[  
-                         72
-                      ],
-                      "name":"Bank",
-                      "scope":73
-                   },
-                   "children":[  
-                      {  
-                         "attributes":{  
-                            "documentation":null,
-                            "implemented":true,
-                            "isConstructor":false,
-                            "kind":"function",
-                            "modifiers":[  
-                               null
-                            ],
-                            "name":"supportsToken",
-                            "scope":72,
-                            "stateMutability":"pure",
-                            "superFunction":null,
-                            "visibility":"external"
-                         },
-                         "children":[  
-                            {  
-                               "attributes":{  
-                                  "parameters":[  
-                                     null
-                                  ]
-                               },
-                               "children":[  
- 
-                               ],
-                               "id":58,
-                               "name":"ParameterList",
-                               "src":"742:2:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "constant":false,
-                                        "name":"",
-                                        "scope":71,
-                                        "stateVariable":false,
-                                        "storageLocation":"default",
-                                        "type":"bytes32",
-                                        "value":null,
-                                        "visibility":"internal"
-                                     },
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "name":"bytes32",
-                                              "type":"bytes32"
-                                           },
-                                           "id":59,
-                                           "name":"ElementaryTypeName",
-                                           "src":"767:7:0"
-                                        }
-                                     ],
-                                     "id":60,
-                                     "name":"VariableDeclaration",
-                                     "src":"767:7:0"
-                                  }
-                               ],
-                               "id":61,
-                               "name":"ParameterList",
-                               "src":"766:9:0"
-                            },
-                            {  
-                               "children":[  
-                                  {  
-                                     "attributes":{  
-                                        "functionReturnParameters":61
-                                     },
-                                     "children":[  
-                                        {  
-                                           "attributes":{  
-                                              "argumentTypes":null,
-                                              "isConstant":false,
-                                              "isInlineArray":false,
-                                              "isLValue":false,
-                                              "isPure":true,
-                                              "lValueRequested":false,
-                                              "type":"bytes32"
-                                           },
-                                           "children":[  
-                                              {  
-                                                 "attributes":{  
-                                                    "argumentTypes":null,
-                                                    "isConstant":false,
-                                                    "isLValue":false,
-                                                    "isPure":true,
-                                                    "isStructConstructorCall":false,
-                                                    "lValueRequested":false,
-                                                    "names":[  
-                                                       null
-                                                    ],
-                                                    "type":"bytes32",
-                                                    "type_conversion":false
-                                                 },
-                                                 "children":[  
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":[  
-                                                             {  
-                                                                "typeIdentifier":"t_bytes_memory_ptr",
-                                                                "typeString":"bytes memory"
-                                                             }
-                                                          ],
-                                                          "overloadedDeclarations":[  
-                                                             null
-                                                          ],
-                                                          "referencedDeclaration":81,
-                                                          "type":"function (bytes memory) pure returns (bytes32)",
-                                                          "value":"keccak256"
-                                                       },
-                                                       "id":62,
-                                                       "name":"Identifier",
-                                                       "src":"792:9:0"
-                                                    },
-                                                    {  
-                                                       "attributes":{  
-                                                          "argumentTypes":null,
-                                                          "isConstant":false,
-                                                          "isLValue":false,
-                                                          "isPure":true,
-                                                          "isStructConstructorCall":false,
-                                                          "lValueRequested":false,
-                                                          "names":[  
-                                                             null
-                                                          ],
-                                                          "type":"bytes memory",
-                                                          "type_conversion":false
-                                                       },
-                                                       "children":[  
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":[  
-                                                                   {  
-                                                                      "typeIdentifier":"t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
-                                                                      "typeString":"literal_string \"Nu Token\""
-                                                                   }
-                                                                ],
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":true,
-                                                                "lValueRequested":false,
-                                                                "member_name":"encodePacked",
-                                                                "referencedDeclaration":null,
-                                                                "type":"function () pure returns (bytes memory)"
-                                                             },
-                                                             "children":[  
-                                                                {  
-                                                                   "attributes":{  
-                                                                      "argumentTypes":null,
-                                                                      "overloadedDeclarations":[  
-                                                                         null
-                                                                      ],
-                                                                      "referencedDeclaration":74,
-                                                                      "type":"abi",
-                                                                      "value":"abi"
-                                                                   },
-                                                                   "id":63,
-                                                                   "name":"Identifier",
-                                                                   "src":"802:3:0"
-                                                                }
-                                                             ],
-                                                             "id":64,
-                                                             "name":"MemberAccess",
-                                                             "src":"802:16:0"
-                                                          },
-                                                          {  
-                                                             "attributes":{  
-                                                                "argumentTypes":null,
-                                                                "hexvalue":"4e7520546f6b656e",
-                                                                "isConstant":false,
-                                                                "isLValue":false,
-                                                                "isPure":true,
-                                                                "lValueRequested":false,
-                                                                "subdenomination":null,
-                                                                "token":"string",
-                                                                "type":"literal_string \"Nu Token\"",
-                                                                "value":"Nu Token"
-                                                             },
-                                                             "id":65,
-                                                             "name":"Literal",
-                                                             "src":"819:10:0"
-                                                          }
-                                                       ],
-                                                       "id":66,
-                                                       "name":"FunctionCall",
-                                                       "src":"802:28:0"
-                                                    }
-                                                 ],
-                                                 "id":67,
-                                                 "name":"FunctionCall",
-                                                 "src":"792:39:0"
-                                              }
-                                           ],
-                                           "id":68,
-                                           "name":"TupleExpression",
-                                           "src":"791:41:0"
-                                        }
-                                     ],
-                                     "id":69,
-                                     "name":"Return",
-                                     "src":"785:47:0"
-                                  }
-                               ],
-                               "id":70,
-                               "name":"Block",
-                               "src":"775:64:0"
-                            }
-                         ],
-                         "id":71,
-                         "name":"FunctionDefinition",
-                         "src":"720:119:0"
-                      }
-                   ],
-                   "id":72,
-                   "name":"ContractDefinition",
-                   "src":"701:140:0"
-                }
-             ],
-             "id":73,
-             "name":"SourceUnit",
-             "src":"0:842:0"
+    "modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol:ModifierEntrancy" : 
+    {
+      "bin" : "608060405234801561001057600080fd5b5061024f806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b1580156100e557600080fd5b505af11580156100f9573d6000803e3d6000fd5b505050506040513d602081101561010f57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461017157600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208c1e8b52bb3fabb6919876400a3ba0d07bb91716a625cfc549ce727ebff53aea0029",
+      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b1580156100e557600080fd5b505af11580156100f9573d6000803e3d6000fd5b505050506040513d602081101561010f57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461017157600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208c1e8b52bb3fabb6919876400a3ba0d07bb91716a625cfc549ce727ebff53aea0029",
+      "srcmap" : "25:674:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:674:0;;;;;;;",
+      "srcmap-runtime" : "25:674:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:674:0;;;;;;;;;;;;;;;;;;;;;;;;223:158;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;223:158;526:10;521:30;;;:32;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;521:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;521:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;521:32:0;;;;;;;;;;;;;;;;488:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;488:28:0;;;478:39;;;;;;:75;470:84;;;;;;681:1;653:12;:24;666:10;653:24;;;;;;;;;;;;;;;;:29;645:38;;;;;;374:2;346:12;:24;359:10;346:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;223:158::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
+    }
+  },
+  "sourceList" : 
+  [
+    "modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol"
+  ],
+  "sources" : 
+  {
+    "modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol" : 
+    {
+      "AST" : 
+      {
+        "attributes" : 
+        {
+          "absolutePath" : "modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol",
+          "exportedSymbols" : 
+          {
+            "Bank" : 
+            [
+              78
+            ],
+            "ModifierEntrancy" : 
+            [
+              57
+            ]
           }
-       }
-    },
-    "version":"0.5.8+commit.23d335f2.Linux.g++"
- }
+        },
+        "children" : 
+        [
+          {
+            "attributes" : 
+            {
+              "literals" : 
+              [
+                "solidity",
+                "^",
+                "0.5",
+                ".0"
+              ]
+            },
+            "id" : 1,
+            "name" : "PragmaDirective",
+            "src" : "0:23:0"
+          },
+          {
+            "attributes" : 
+            {
+              "baseContracts" : 
+              [
+                null
+              ],
+              "contractDependencies" : 
+              [
+                null
+              ],
+              "contractKind" : "contract",
+              "documentation" : null,
+              "fullyImplemented" : true,
+              "linearizedBaseContracts" : 
+              [
+                57
+              ],
+              "name" : "ModifierEntrancy",
+              "scope" : 79
+            },
+            "children" : 
+            [
+              {
+                "attributes" : 
+                {
+                  "constant" : false,
+                  "name" : "tokenBalance",
+                  "scope" : 57,
+                  "stateVariable" : true,
+                  "storageLocation" : "default",
+                  "type" : "mapping(address => uint256)",
+                  "value" : null,
+                  "visibility" : "public"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "type" : "mapping(address => uint256)"
+                    },
+                    "children" : 
+                    [
+                      {
+                        "attributes" : 
+                        {
+                          "name" : "address",
+                          "type" : "address"
+                        },
+                        "id" : 2,
+                        "name" : "ElementaryTypeName",
+                        "src" : "64:7:0"
+                      },
+                      {
+                        "attributes" : 
+                        {
+                          "name" : "uint",
+                          "type" : "uint256"
+                        },
+                        "id" : 3,
+                        "name" : "ElementaryTypeName",
+                        "src" : "75:4:0"
+                      }
+                    ],
+                    "id" : 4,
+                    "name" : "Mapping",
+                    "src" : "55:25:0"
+                  }
+                ],
+                "id" : 5,
+                "name" : "VariableDeclaration",
+                "src" : "55:45:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "constant" : true,
+                  "name" : "name",
+                  "scope" : 57,
+                  "stateVariable" : true,
+                  "storageLocation" : "default",
+                  "type" : "string",
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "name" : "string",
+                      "type" : "string"
+                    },
+                    "id" : 6,
+                    "name" : "ElementaryTypeName",
+                    "src" : "104:6:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "argumentTypes" : null,
+                      "hexvalue" : "4e7520546f6b656e",
+                      "isConstant" : false,
+                      "isLValue" : false,
+                      "isPure" : true,
+                      "lValueRequested" : false,
+                      "subdenomination" : null,
+                      "token" : "string",
+                      "type" : "literal_string \"Nu Token\"",
+                      "value" : "Nu Token"
+                    },
+                    "id" : 7,
+                    "name" : "Literal",
+                    "src" : "127:10:0"
+                  }
+                ],
+                "id" : 8,
+                "name" : "VariableDeclaration",
+                "src" : "104:33:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "implemented" : true,
+                  "isConstructor" : false,
+                  "kind" : "function",
+                  "name" : "airDrop",
+                  "scope" : 57,
+                  "stateMutability" : "nonpayable",
+                  "superFunction" : null,
+                  "visibility" : "public"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 9,
+                    "name" : "ParameterList",
+                    "src" : "239:2:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 14,
+                    "name" : "ParameterList",
+                    "src" : "276:0:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "arguments" : null
+                    },
+                    "children" : 
+                    [
+                      {
+                        "attributes" : 
+                        {
+                          "argumentTypes" : null,
+                          "overloadedDeclarations" : 
+                          [
+                            null
+                          ],
+                          "referencedDeclaration" : 43,
+                          "type" : "modifier ()",
+                          "value" : "supportsToken"
+                        },
+                        "id" : 10,
+                        "name" : "Identifier",
+                        "src" : "242:13:0"
+                      }
+                    ],
+                    "id" : 11,
+                    "name" : "ModifierInvocation",
+                    "src" : "242:13:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "arguments" : null
+                    },
+                    "children" : 
+                    [
+                      {
+                        "attributes" : 
+                        {
+                          "argumentTypes" : null,
+                          "overloadedDeclarations" : 
+                          [
+                            null
+                          ],
+                          "referencedDeclaration" : 56,
+                          "type" : "modifier ()",
+                          "value" : "hasNoBalance"
+                        },
+                        "id" : 12,
+                        "name" : "Identifier",
+                        "src" : "256:12:0"
+                      }
+                    ],
+                    "id" : 13,
+                    "name" : "ModifierInvocation",
+                    "src" : "256:12:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "lValueRequested" : false,
+                              "operator" : "+=",
+                              "type" : "uint256"
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "isConstant" : false,
+                                  "isLValue" : true,
+                                  "isPure" : false,
+                                  "lValueRequested" : true,
+                                  "type" : "uint256"
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "overloadedDeclarations" : 
+                                      [
+                                        null
+                                      ],
+                                      "referencedDeclaration" : 5,
+                                      "type" : "mapping(address => uint256)",
+                                      "value" : "tokenBalance"
+                                    },
+                                    "id" : 15,
+                                    "name" : "Identifier",
+                                    "src" : "346:12:0"
+                                  },
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : false,
+                                      "lValueRequested" : false,
+                                      "member_name" : "sender",
+                                      "referencedDeclaration" : null,
+                                      "type" : "address payable"
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "overloadedDeclarations" : 
+                                          [
+                                            null
+                                          ],
+                                          "referencedDeclaration" : 93,
+                                          "type" : "msg",
+                                          "value" : "msg"
+                                        },
+                                        "id" : 16,
+                                        "name" : "Identifier",
+                                        "src" : "359:3:0"
+                                      }
+                                    ],
+                                    "id" : 17,
+                                    "name" : "MemberAccess",
+                                    "src" : "359:10:0"
+                                  }
+                                ],
+                                "id" : 18,
+                                "name" : "IndexAccess",
+                                "src" : "346:24:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "hexvalue" : "3230",
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : true,
+                                  "lValueRequested" : false,
+                                  "subdenomination" : null,
+                                  "token" : "number",
+                                  "type" : "int_const 20",
+                                  "value" : "20"
+                                },
+                                "id" : 19,
+                                "name" : "Literal",
+                                "src" : "374:2:0"
+                              }
+                            ],
+                            "id" : 20,
+                            "name" : "Assignment",
+                            "src" : "346:30:0"
+                          }
+                        ],
+                        "id" : 21,
+                        "name" : "ExpressionStatement",
+                        "src" : "346:30:0"
+                      }
+                    ],
+                    "id" : 22,
+                    "name" : "Block",
+                    "src" : "276:105:0"
+                  }
+                ],
+                "id" : 23,
+                "name" : "FunctionDefinition",
+                "src" : "223:158:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "name" : "supportsToken",
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 24,
+                    "name" : "ParameterList",
+                    "src" : "461:2:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "isStructConstructorCall" : false,
+                              "lValueRequested" : false,
+                              "names" : 
+                              [
+                                null
+                              ],
+                              "type" : "tuple()",
+                              "type_conversion" : false
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : 
+                                  [
+                                    {
+                                      "typeIdentifier" : "t_bool",
+                                      "typeString" : "bool"
+                                    }
+                                  ],
+                                  "overloadedDeclarations" : 
+                                  [
+                                    96,
+                                    97
+                                  ],
+                                  "referencedDeclaration" : 96,
+                                  "type" : "function (bool) pure",
+                                  "value" : "require"
+                                },
+                                "id" : 25,
+                                "name" : "Identifier",
+                                "src" : "470:7:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "commonType" : 
+                                  {
+                                    "typeIdentifier" : "t_bytes32",
+                                    "typeString" : "bytes32"
+                                  },
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : false,
+                                  "lValueRequested" : false,
+                                  "operator" : "==",
+                                  "type" : "bool"
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : true,
+                                      "isStructConstructorCall" : false,
+                                      "lValueRequested" : false,
+                                      "names" : 
+                                      [
+                                        null
+                                      ],
+                                      "type" : "bytes32",
+                                      "type_conversion" : false
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : 
+                                          [
+                                            {
+                                              "typeIdentifier" : "t_bytes_memory_ptr",
+                                              "typeString" : "bytes memory"
+                                            }
+                                          ],
+                                          "overloadedDeclarations" : 
+                                          [
+                                            null
+                                          ],
+                                          "referencedDeclaration" : 87,
+                                          "type" : "function (bytes memory) pure returns (bytes32)",
+                                          "value" : "keccak256"
+                                        },
+                                        "id" : 26,
+                                        "name" : "Identifier",
+                                        "src" : "478:9:0"
+                                      },
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : true,
+                                          "isStructConstructorCall" : false,
+                                          "lValueRequested" : false,
+                                          "names" : 
+                                          [
+                                            null
+                                          ],
+                                          "type" : "bytes memory",
+                                          "type_conversion" : false
+                                        },
+                                        "children" : 
+                                        [
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : 
+                                              [
+                                                {
+                                                  "typeIdentifier" : "t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
+                                                  "typeString" : "literal_string \"Nu Token\""
+                                                }
+                                              ],
+                                              "isConstant" : false,
+                                              "isLValue" : false,
+                                              "isPure" : true,
+                                              "lValueRequested" : false,
+                                              "member_name" : "encodePacked",
+                                              "referencedDeclaration" : null,
+                                              "type" : "function () pure returns (bytes memory)"
+                                            },
+                                            "children" : 
+                                            [
+                                              {
+                                                "attributes" : 
+                                                {
+                                                  "argumentTypes" : null,
+                                                  "overloadedDeclarations" : 
+                                                  [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration" : 80,
+                                                  "type" : "abi",
+                                                  "value" : "abi"
+                                                },
+                                                "id" : 27,
+                                                "name" : "Identifier",
+                                                "src" : "488:3:0"
+                                              }
+                                            ],
+                                            "id" : 28,
+                                            "name" : "MemberAccess",
+                                            "src" : "488:16:0"
+                                          },
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : null,
+                                              "hexvalue" : "4e7520546f6b656e",
+                                              "isConstant" : false,
+                                              "isLValue" : false,
+                                              "isPure" : true,
+                                              "lValueRequested" : false,
+                                              "subdenomination" : null,
+                                              "token" : "string",
+                                              "type" : "literal_string \"Nu Token\"",
+                                              "value" : "Nu Token"
+                                            },
+                                            "id" : 29,
+                                            "name" : "Literal",
+                                            "src" : "505:10:0"
+                                          }
+                                        ],
+                                        "id" : 30,
+                                        "name" : "FunctionCall",
+                                        "src" : "488:28:0"
+                                      }
+                                    ],
+                                    "id" : 31,
+                                    "name" : "FunctionCall",
+                                    "src" : "478:39:0"
+                                  },
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "arguments" : 
+                                      [
+                                        null
+                                      ],
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : false,
+                                      "isStructConstructorCall" : false,
+                                      "lValueRequested" : false,
+                                      "names" : 
+                                      [
+                                        null
+                                      ],
+                                      "type" : "bytes32",
+                                      "type_conversion" : false
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : 
+                                          [
+                                            null
+                                          ],
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : false,
+                                          "lValueRequested" : false,
+                                          "member_name" : "supportsToken",
+                                          "referencedDeclaration" : 77,
+                                          "type" : "function () external returns (bytes32)"
+                                        },
+                                        "children" : 
+                                        [
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : null,
+                                              "isConstant" : false,
+                                              "isLValue" : false,
+                                              "isPure" : false,
+                                              "isStructConstructorCall" : false,
+                                              "lValueRequested" : false,
+                                              "names" : 
+                                              [
+                                                null
+                                              ],
+                                              "type" : "contract Bank",
+                                              "type_conversion" : true
+                                            },
+                                            "children" : 
+                                            [
+                                              {
+                                                "attributes" : 
+                                                {
+                                                  "argumentTypes" : 
+                                                  [
+                                                    {
+                                                      "typeIdentifier" : "t_address_payable",
+                                                      "typeString" : "address payable"
+                                                    }
+                                                  ],
+                                                  "overloadedDeclarations" : 
+                                                  [
+                                                    null
+                                                  ],
+                                                  "referencedDeclaration" : 78,
+                                                  "type" : "type(contract Bank)",
+                                                  "value" : "Bank"
+                                                },
+                                                "id" : 32,
+                                                "name" : "Identifier",
+                                                "src" : "521:4:0"
+                                              },
+                                              {
+                                                "attributes" : 
+                                                {
+                                                  "argumentTypes" : null,
+                                                  "isConstant" : false,
+                                                  "isLValue" : false,
+                                                  "isPure" : false,
+                                                  "lValueRequested" : false,
+                                                  "member_name" : "sender",
+                                                  "referencedDeclaration" : null,
+                                                  "type" : "address payable"
+                                                },
+                                                "children" : 
+                                                [
+                                                  {
+                                                    "attributes" : 
+                                                    {
+                                                      "argumentTypes" : null,
+                                                      "overloadedDeclarations" : 
+                                                      [
+                                                        null
+                                                      ],
+                                                      "referencedDeclaration" : 93,
+                                                      "type" : "msg",
+                                                      "value" : "msg"
+                                                    },
+                                                    "id" : 33,
+                                                    "name" : "Identifier",
+                                                    "src" : "526:3:0"
+                                                  }
+                                                ],
+                                                "id" : 34,
+                                                "name" : "MemberAccess",
+                                                "src" : "526:10:0"
+                                              }
+                                            ],
+                                            "id" : 35,
+                                            "name" : "FunctionCall",
+                                            "src" : "521:16:0"
+                                          }
+                                        ],
+                                        "id" : 36,
+                                        "name" : "MemberAccess",
+                                        "src" : "521:30:0"
+                                      }
+                                    ],
+                                    "id" : 37,
+                                    "name" : "FunctionCall",
+                                    "src" : "521:32:0"
+                                  }
+                                ],
+                                "id" : 38,
+                                "name" : "BinaryOperation",
+                                "src" : "478:75:0"
+                              }
+                            ],
+                            "id" : 39,
+                            "name" : "FunctionCall",
+                            "src" : "470:84:0"
+                          }
+                        ],
+                        "id" : 40,
+                        "name" : "ExpressionStatement",
+                        "src" : "470:84:0"
+                      },
+                      {
+                        "id" : 41,
+                        "name" : "PlaceholderStatement",
+                        "src" : "560:1:0"
+                      }
+                    ],
+                    "id" : 42,
+                    "name" : "Block",
+                    "src" : "464:102:0"
+                  }
+                ],
+                "id" : 43,
+                "name" : "ModifierDefinition",
+                "src" : "439:127:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "name" : "hasNoBalance",
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 44,
+                    "name" : "ParameterList",
+                    "src" : "637:0:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "isStructConstructorCall" : false,
+                              "lValueRequested" : false,
+                              "names" : 
+                              [
+                                null
+                              ],
+                              "type" : "tuple()",
+                              "type_conversion" : false
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : 
+                                  [
+                                    {
+                                      "typeIdentifier" : "t_bool",
+                                      "typeString" : "bool"
+                                    }
+                                  ],
+                                  "overloadedDeclarations" : 
+                                  [
+                                    96,
+                                    97
+                                  ],
+                                  "referencedDeclaration" : 96,
+                                  "type" : "function (bool) pure",
+                                  "value" : "require"
+                                },
+                                "id" : 45,
+                                "name" : "Identifier",
+                                "src" : "645:7:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "commonType" : 
+                                  {
+                                    "typeIdentifier" : "t_uint256",
+                                    "typeString" : "uint256"
+                                  },
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : false,
+                                  "lValueRequested" : false,
+                                  "operator" : "==",
+                                  "type" : "bool"
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "isConstant" : false,
+                                      "isLValue" : true,
+                                      "isPure" : false,
+                                      "lValueRequested" : false,
+                                      "type" : "uint256"
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "overloadedDeclarations" : 
+                                          [
+                                            null
+                                          ],
+                                          "referencedDeclaration" : 5,
+                                          "type" : "mapping(address => uint256)",
+                                          "value" : "tokenBalance"
+                                        },
+                                        "id" : 46,
+                                        "name" : "Identifier",
+                                        "src" : "653:12:0"
+                                      },
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : false,
+                                          "lValueRequested" : false,
+                                          "member_name" : "sender",
+                                          "referencedDeclaration" : null,
+                                          "type" : "address payable"
+                                        },
+                                        "children" : 
+                                        [
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : null,
+                                              "overloadedDeclarations" : 
+                                              [
+                                                null
+                                              ],
+                                              "referencedDeclaration" : 93,
+                                              "type" : "msg",
+                                              "value" : "msg"
+                                            },
+                                            "id" : 47,
+                                            "name" : "Identifier",
+                                            "src" : "666:3:0"
+                                          }
+                                        ],
+                                        "id" : 48,
+                                        "name" : "MemberAccess",
+                                        "src" : "666:10:0"
+                                      }
+                                    ],
+                                    "id" : 49,
+                                    "name" : "IndexAccess",
+                                    "src" : "653:24:0"
+                                  },
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "hexvalue" : "30",
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : true,
+                                      "lValueRequested" : false,
+                                      "subdenomination" : null,
+                                      "token" : "number",
+                                      "type" : "int_const 0",
+                                      "value" : "0"
+                                    },
+                                    "id" : 50,
+                                    "name" : "Literal",
+                                    "src" : "681:1:0"
+                                  }
+                                ],
+                                "id" : 51,
+                                "name" : "BinaryOperation",
+                                "src" : "653:29:0"
+                              }
+                            ],
+                            "id" : 52,
+                            "name" : "FunctionCall",
+                            "src" : "645:38:0"
+                          }
+                        ],
+                        "id" : 53,
+                        "name" : "ExpressionStatement",
+                        "src" : "645:38:0"
+                      },
+                      {
+                        "id" : 54,
+                        "name" : "PlaceholderStatement",
+                        "src" : "691:1:0"
+                      }
+                    ],
+                    "id" : 55,
+                    "name" : "Block",
+                    "src" : "637:60:0"
+                  }
+                ],
+                "id" : 56,
+                "name" : "ModifierDefinition",
+                "src" : "615:82:0"
+              }
+            ],
+            "id" : 57,
+            "name" : "ContractDefinition",
+            "src" : "25:674:0"
+          },
+          {
+            "attributes" : 
+            {
+              "baseContracts" : 
+              [
+                null
+              ],
+              "contractDependencies" : 
+              [
+                null
+              ],
+              "contractKind" : "contract",
+              "documentation" : null,
+              "fullyImplemented" : true,
+              "linearizedBaseContracts" : 
+              [
+                78
+              ],
+              "name" : "Bank",
+              "scope" : 79
+            },
+            "children" : 
+            [
+              {
+                "attributes" : 
+                {
+                  "constant" : false,
+                  "name" : "state_var",
+                  "scope" : 78,
+                  "stateVariable" : true,
+                  "storageLocation" : "default",
+                  "type" : "uint256",
+                  "value" : null,
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "name" : "uint",
+                      "type" : "uint256"
+                    },
+                    "id" : 58,
+                    "name" : "ElementaryTypeName",
+                    "src" : "720:4:0"
+                  }
+                ],
+                "id" : 59,
+                "name" : "VariableDeclaration",
+                "src" : "720:14:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "implemented" : true,
+                  "isConstructor" : false,
+                  "kind" : "function",
+                  "modifiers" : 
+                  [
+                    null
+                  ],
+                  "name" : "supportsToken",
+                  "scope" : 78,
+                  "stateMutability" : "nonpayable",
+                  "superFunction" : null,
+                  "visibility" : "external"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 60,
+                    "name" : "ParameterList",
+                    "src" : "762:2:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "attributes" : 
+                        {
+                          "constant" : false,
+                          "name" : "",
+                          "scope" : 77,
+                          "stateVariable" : false,
+                          "storageLocation" : "default",
+                          "type" : "bytes32",
+                          "value" : null,
+                          "visibility" : "internal"
+                        },
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "name" : "bytes32",
+                              "type" : "bytes32"
+                            },
+                            "id" : 61,
+                            "name" : "ElementaryTypeName",
+                            "src" : "782:7:0"
+                          }
+                        ],
+                        "id" : 62,
+                        "name" : "VariableDeclaration",
+                        "src" : "782:7:0"
+                      }
+                    ],
+                    "id" : 63,
+                    "name" : "ParameterList",
+                    "src" : "781:9:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "lValueRequested" : false,
+                              "operator" : "=",
+                              "type" : "uint256"
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "overloadedDeclarations" : 
+                                  [
+                                    null
+                                  ],
+                                  "referencedDeclaration" : 59,
+                                  "type" : "uint256",
+                                  "value" : "state_var"
+                                },
+                                "id" : 64,
+                                "name" : "Identifier",
+                                "src" : "800:9:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "hexvalue" : "31",
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : true,
+                                  "lValueRequested" : false,
+                                  "subdenomination" : null,
+                                  "token" : "number",
+                                  "type" : "int_const 1",
+                                  "value" : "1"
+                                },
+                                "id" : 65,
+                                "name" : "Literal",
+                                "src" : "812:1:0"
+                              }
+                            ],
+                            "id" : 66,
+                            "name" : "Assignment",
+                            "src" : "800:13:0"
+                          }
+                        ],
+                        "id" : 67,
+                        "name" : "ExpressionStatement",
+                        "src" : "800:13:0"
+                      },
+                      {
+                        "attributes" : 
+                        {
+                          "functionReturnParameters" : 63
+                        },
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isInlineArray" : false,
+                              "isLValue" : false,
+                              "isPure" : true,
+                              "lValueRequested" : false,
+                              "type" : "bytes32"
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : true,
+                                  "isStructConstructorCall" : false,
+                                  "lValueRequested" : false,
+                                  "names" : 
+                                  [
+                                    null
+                                  ],
+                                  "type" : "bytes32",
+                                  "type_conversion" : false
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : 
+                                      [
+                                        {
+                                          "typeIdentifier" : "t_bytes_memory_ptr",
+                                          "typeString" : "bytes memory"
+                                        }
+                                      ],
+                                      "overloadedDeclarations" : 
+                                      [
+                                        null
+                                      ],
+                                      "referencedDeclaration" : 87,
+                                      "type" : "function (bytes memory) pure returns (bytes32)",
+                                      "value" : "keccak256"
+                                    },
+                                    "id" : 68,
+                                    "name" : "Identifier",
+                                    "src" : "830:9:0"
+                                  },
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : null,
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : true,
+                                      "isStructConstructorCall" : false,
+                                      "lValueRequested" : false,
+                                      "names" : 
+                                      [
+                                        null
+                                      ],
+                                      "type" : "bytes memory",
+                                      "type_conversion" : false
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : 
+                                          [
+                                            {
+                                              "typeIdentifier" : "t_stringliteral_17862392b11fe545de9f050c1f51088aad194edcf90df74bb8e5d043dc83b271",
+                                              "typeString" : "literal_string \"Nu Token\""
+                                            }
+                                          ],
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : true,
+                                          "lValueRequested" : false,
+                                          "member_name" : "encodePacked",
+                                          "referencedDeclaration" : null,
+                                          "type" : "function () pure returns (bytes memory)"
+                                        },
+                                        "children" : 
+                                        [
+                                          {
+                                            "attributes" : 
+                                            {
+                                              "argumentTypes" : null,
+                                              "overloadedDeclarations" : 
+                                              [
+                                                null
+                                              ],
+                                              "referencedDeclaration" : 80,
+                                              "type" : "abi",
+                                              "value" : "abi"
+                                            },
+                                            "id" : 69,
+                                            "name" : "Identifier",
+                                            "src" : "840:3:0"
+                                          }
+                                        ],
+                                        "id" : 70,
+                                        "name" : "MemberAccess",
+                                        "src" : "840:16:0"
+                                      },
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "argumentTypes" : null,
+                                          "hexvalue" : "4e7520546f6b656e",
+                                          "isConstant" : false,
+                                          "isLValue" : false,
+                                          "isPure" : true,
+                                          "lValueRequested" : false,
+                                          "subdenomination" : null,
+                                          "token" : "string",
+                                          "type" : "literal_string \"Nu Token\"",
+                                          "value" : "Nu Token"
+                                        },
+                                        "id" : 71,
+                                        "name" : "Literal",
+                                        "src" : "857:10:0"
+                                      }
+                                    ],
+                                    "id" : 72,
+                                    "name" : "FunctionCall",
+                                    "src" : "840:28:0"
+                                  }
+                                ],
+                                "id" : 73,
+                                "name" : "FunctionCall",
+                                "src" : "830:39:0"
+                              }
+                            ],
+                            "id" : 74,
+                            "name" : "TupleExpression",
+                            "src" : "829:41:0"
+                          }
+                        ],
+                        "id" : 75,
+                        "name" : "Return",
+                        "src" : "823:47:0"
+                      }
+                    ],
+                    "id" : 76,
+                    "name" : "Block",
+                    "src" : "790:87:0"
+                  }
+                ],
+                "id" : 77,
+                "name" : "FunctionDefinition",
+                "src" : "740:137:0"
+              }
+            ],
+            "id" : 78,
+            "name" : "ContractDefinition",
+            "src" : "701:178:0"
+          }
+        ],
+        "id" : 79,
+        "name" : "SourceUnit",
+        "src" : "0:880:0"
+      }
+    }
+  },
+  "version" : "0.5.6+commit.b259423e.Linux.g++"
+}

--- a/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.json
+++ b/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.json
@@ -3,17 +3,17 @@
   {
     "modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol:Bank" : 
     {
-      "bin" : "6080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820a17c196af6cd011669c8624a23d7c075e95b4538bfac3edb06ccaf04936b59ed0029",
-      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820a17c196af6cd011669c8624a23d7c075e95b4538bfac3edb06ccaf04936b59ed0029",
-      "srcmap" : "701:136:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:136:0;;;;;;;",
-      "srcmap-runtime" : "701:136:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:136:0;;;;;;;;;;;;;;;;;;;721:114;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;763:7;798:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;798:28:0;;;788:39;;;;;;781:47;;721:114;:::o"
+      "bin" : "6080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820641af90217223cb7a066efe7bb4d93b09c4658f4ed0cd063f35ca850f8cb21e60029",
+      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820641af90217223cb7a066efe7bb4d93b09c4658f4ed0cd063f35ca850f8cb21e60029",
+      "srcmap" : "755:136:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;755:136:0;;;;;;;",
+      "srcmap-runtime" : "755:136:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;755:136:0;;;;;;;;;;;;;;;;;;;775:114;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;817:7;852:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;852:28:0;;;842:39;;;;;;835:47;;775:114;:::o"
     },
     "modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol:ModifierEntrancy" : 
     {
-      "bin" : "608060405234801561001057600080fd5b5061024f806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b1580156100e557600080fd5b505af11580156100f9573d6000803e3d6000fd5b505050506040513d602081101561010f57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461017157600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058209f76f51b29f6f5aeb4d21da2190521394d23b63c9c21b863f126f27f9aadb6580029",
-      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b1580156100e557600080fd5b505af11580156100f9573d6000803e3d6000fd5b505050506040513d602081101561010f57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461017157600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058209f76f51b29f6f5aeb4d21da2190521394d23b63c9c21b863f126f27f9aadb6580029",
-      "srcmap" : "25:674:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:674:0;;;;;;;",
-      "srcmap-runtime" : "25:674:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:674:0;;;;;;;;;;;;;;;;;;;;;;;;223:158;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;223:158;526:10;521:30;;;:32;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;521:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;521:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;521:32:0;;;;;;;;;;;;;;;;488:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;488:28:0;;;478:39;;;;;;:75;470:84;;;;;;681:1;653:12;:24;666:10;653:24;;;;;;;;;;;;;;;;:29;645:38;;;;;;374:2;346:12;:24;359:10;346:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;223:158::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
+      "bin" : "608060405234801561001057600080fd5b5060405161001d9061007f565b604051809103906000f080158015610039573d6000803e3d6000fd5b50600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555061008b565b60e18061030b83390190565b6102718061009a6000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061022d565b6040518082815260200191505060405180910390f35b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561010757600080fd5b505af115801561011b573d6000803e3d6000fd5b505050506040513d602081101561013157600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461019357600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101de57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a7230582026ce4a3fdcc2cae0efbd5e0d32b91277c27e7c828e1ea6c7fbc92f5f9befad1c00296080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820641af90217223cb7a066efe7bb4d93b09c4658f4ed0cd063f35ca850f8cb21e60029",
+      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061022d565b6040518082815260200191505060405180910390f35b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b15801561010757600080fd5b505af115801561011b573d6000803e3d6000fd5b505050506040513d602081101561013157600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461019357600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101de57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a7230582026ce4a3fdcc2cae0efbd5e0d32b91277c27e7c828e1ea6c7fbc92f5f9befad1c0029",
+      "srcmap" : "25:728:0:-;;;154:50;8:9:-1;5:2;;;30:1;27;20:12;5:2;154:50:0;189:10;;;;;:::i;:::-;;;;;;;;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;189:10:0;182:4;;:17;;;;;;;;;;;;;;;;;;25:728;;;;;;;;;;:::o;:::-;;;;;;;",
+      "srcmap-runtime" : "25:728:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:728:0;;;;;;;;;;;;;;;;;;;;;;;;289:158;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;289:158;587:4;;;;;;;;;;;:18;;;:20;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;587:20:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;587:20:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;587:20:0;;;;;;;;;;;;;;;;554:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;554:28:0;;;544:39;;;;;;:63;536:72;;;;;;735:1;707:12;:24;720:10;707:24;;;;;;;;;;;;;;;;:29;699:38;;;;;;440:2;412:12;:24;425:10;412:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;289:158::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
     }
   },
   "sourceList" : 
@@ -33,11 +33,11 @@
           {
             "Bank" : 
             [
-              72
+              81
             ],
             "ModifierEntrancy" : 
             [
-              57
+              66
             ]
           }
         },
@@ -67,17 +67,17 @@
               ],
               "contractDependencies" : 
               [
-                null
+                81
               ],
               "contractKind" : "contract",
               "documentation" : null,
               "fullyImplemented" : true,
               "linearizedBaseContracts" : 
               [
-                57
+                66
               ],
               "name" : "ModifierEntrancy",
-              "scope" : 73
+              "scope" : 82
             },
             "children" : 
             [
@@ -86,7 +86,7 @@
                 {
                   "constant" : false,
                   "name" : "tokenBalance",
-                  "scope" : 57,
+                  "scope" : 66,
                   "stateVariable" : true,
                   "storageLocation" : "default",
                   "type" : "mapping(address => uint256)",
@@ -137,7 +137,7 @@
                 {
                   "constant" : true,
                   "name" : "name",
-                  "scope" : 57,
+                  "scope" : 66,
                   "stateVariable" : true,
                   "storageLocation" : "default",
                   "type" : "string",
@@ -181,12 +181,47 @@
               {
                 "attributes" : 
                 {
+                  "constant" : false,
+                  "name" : "bank",
+                  "scope" : 66,
+                  "stateVariable" : true,
+                  "storageLocation" : "default",
+                  "type" : "contract Bank",
+                  "value" : null,
+                  "visibility" : "internal"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "contractScope" : null,
+                      "name" : "Bank",
+                      "referencedDeclaration" : 81,
+                      "type" : "contract Bank"
+                    },
+                    "id" : 9,
+                    "name" : "UserDefinedTypeName",
+                    "src" : "141:4:0"
+                  }
+                ],
+                "id" : 10,
+                "name" : "VariableDeclaration",
+                "src" : "141:9:0"
+              },
+              {
+                "attributes" : 
+                {
                   "documentation" : null,
                   "implemented" : true,
-                  "isConstructor" : false,
-                  "kind" : "function",
-                  "name" : "airDrop",
-                  "scope" : 57,
+                  "isConstructor" : true,
+                  "kind" : "constructor",
+                  "modifiers" : 
+                  [
+                    null
+                  ],
+                  "name" : "",
+                  "scope" : 66,
                   "stateMutability" : "nonpayable",
                   "superFunction" : null,
                   "visibility" : "public"
@@ -202,9 +237,9 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 9,
+                    "id" : 11,
                     "name" : "ParameterList",
-                    "src" : "239:2:0"
+                    "src" : "165:2:0"
                   },
                   {
                     "attributes" : 
@@ -215,9 +250,164 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 14,
+                    "id" : 12,
                     "name" : "ParameterList",
-                    "src" : "276:0:0"
+                    "src" : "174:0:0"
+                  },
+                  {
+                    "children" : 
+                    [
+                      {
+                        "children" : 
+                        [
+                          {
+                            "attributes" : 
+                            {
+                              "argumentTypes" : null,
+                              "isConstant" : false,
+                              "isLValue" : false,
+                              "isPure" : false,
+                              "lValueRequested" : false,
+                              "operator" : "=",
+                              "type" : "contract Bank"
+                            },
+                            "children" : 
+                            [
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "overloadedDeclarations" : 
+                                  [
+                                    null
+                                  ],
+                                  "referencedDeclaration" : 10,
+                                  "type" : "contract Bank",
+                                  "value" : "bank"
+                                },
+                                "id" : 13,
+                                "name" : "Identifier",
+                                "src" : "182:4:0"
+                              },
+                              {
+                                "attributes" : 
+                                {
+                                  "argumentTypes" : null,
+                                  "arguments" : 
+                                  [
+                                    null
+                                  ],
+                                  "isConstant" : false,
+                                  "isLValue" : false,
+                                  "isPure" : false,
+                                  "isStructConstructorCall" : false,
+                                  "lValueRequested" : false,
+                                  "names" : 
+                                  [
+                                    null
+                                  ],
+                                  "type" : "contract Bank",
+                                  "type_conversion" : false
+                                },
+                                "children" : 
+                                [
+                                  {
+                                    "attributes" : 
+                                    {
+                                      "argumentTypes" : 
+                                      [
+                                        null
+                                      ],
+                                      "isConstant" : false,
+                                      "isLValue" : false,
+                                      "isPure" : false,
+                                      "lValueRequested" : false,
+                                      "type" : "function () returns (contract Bank)"
+                                    },
+                                    "children" : 
+                                    [
+                                      {
+                                        "attributes" : 
+                                        {
+                                          "contractScope" : null,
+                                          "name" : "Bank",
+                                          "referencedDeclaration" : 81,
+                                          "type" : "contract Bank"
+                                        },
+                                        "id" : 14,
+                                        "name" : "UserDefinedTypeName",
+                                        "src" : "193:4:0"
+                                      }
+                                    ],
+                                    "id" : 15,
+                                    "name" : "NewExpression",
+                                    "src" : "189:8:0"
+                                  }
+                                ],
+                                "id" : 16,
+                                "name" : "FunctionCall",
+                                "src" : "189:10:0"
+                              }
+                            ],
+                            "id" : 17,
+                            "name" : "Assignment",
+                            "src" : "182:17:0"
+                          }
+                        ],
+                        "id" : 18,
+                        "name" : "ExpressionStatement",
+                        "src" : "182:17:0"
+                      }
+                    ],
+                    "id" : 19,
+                    "name" : "Block",
+                    "src" : "174:30:0"
+                  }
+                ],
+                "id" : 20,
+                "name" : "FunctionDefinition",
+                "src" : "154:50:0"
+              },
+              {
+                "attributes" : 
+                {
+                  "documentation" : null,
+                  "implemented" : true,
+                  "isConstructor" : false,
+                  "kind" : "function",
+                  "name" : "airDrop",
+                  "scope" : 66,
+                  "stateMutability" : "nonpayable",
+                  "superFunction" : null,
+                  "visibility" : "public"
+                },
+                "children" : 
+                [
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 21,
+                    "name" : "ParameterList",
+                    "src" : "305:2:0"
+                  },
+                  {
+                    "attributes" : 
+                    {
+                      "parameters" : 
+                      [
+                        null
+                      ]
+                    },
+                    "children" : [],
+                    "id" : 26,
+                    "name" : "ParameterList",
+                    "src" : "342:0:0"
                   },
                   {
                     "attributes" : 
@@ -234,18 +424,18 @@
                           [
                             null
                           ],
-                          "referencedDeclaration" : 43,
+                          "referencedDeclaration" : 52,
                           "type" : "modifier ()",
                           "value" : "supportsToken"
                         },
-                        "id" : 10,
+                        "id" : 22,
                         "name" : "Identifier",
-                        "src" : "242:13:0"
+                        "src" : "308:13:0"
                       }
                     ],
-                    "id" : 11,
+                    "id" : 23,
                     "name" : "ModifierInvocation",
-                    "src" : "242:13:0"
+                    "src" : "308:13:0"
                   },
                   {
                     "attributes" : 
@@ -262,18 +452,18 @@
                           [
                             null
                           ],
-                          "referencedDeclaration" : 56,
+                          "referencedDeclaration" : 65,
                           "type" : "modifier ()",
                           "value" : "hasNoBalance"
                         },
-                        "id" : 12,
+                        "id" : 24,
                         "name" : "Identifier",
-                        "src" : "256:12:0"
+                        "src" : "322:12:0"
                       }
                     ],
-                    "id" : 13,
+                    "id" : 25,
                     "name" : "ModifierInvocation",
-                    "src" : "256:12:0"
+                    "src" : "322:12:0"
                   },
                   {
                     "children" : 
@@ -318,9 +508,9 @@
                                       "type" : "mapping(address => uint256)",
                                       "value" : "tokenBalance"
                                     },
-                                    "id" : 15,
+                                    "id" : 27,
                                     "name" : "Identifier",
-                                    "src" : "346:12:0"
+                                    "src" : "412:12:0"
                                   },
                                   {
                                     "attributes" : 
@@ -344,23 +534,23 @@
                                           [
                                             null
                                           ],
-                                          "referencedDeclaration" : 87,
+                                          "referencedDeclaration" : 96,
                                           "type" : "msg",
                                           "value" : "msg"
                                         },
-                                        "id" : 16,
+                                        "id" : 28,
                                         "name" : "Identifier",
-                                        "src" : "359:3:0"
+                                        "src" : "425:3:0"
                                       }
                                     ],
-                                    "id" : 17,
+                                    "id" : 29,
                                     "name" : "MemberAccess",
-                                    "src" : "359:10:0"
+                                    "src" : "425:10:0"
                                   }
                                 ],
-                                "id" : 18,
+                                "id" : 30,
                                 "name" : "IndexAccess",
-                                "src" : "346:24:0"
+                                "src" : "412:24:0"
                               },
                               {
                                 "attributes" : 
@@ -376,29 +566,29 @@
                                   "type" : "int_const 20",
                                   "value" : "20"
                                 },
-                                "id" : 19,
+                                "id" : 31,
                                 "name" : "Literal",
-                                "src" : "374:2:0"
+                                "src" : "440:2:0"
                               }
                             ],
-                            "id" : 20,
+                            "id" : 32,
                             "name" : "Assignment",
-                            "src" : "346:30:0"
+                            "src" : "412:30:0"
                           }
                         ],
-                        "id" : 21,
+                        "id" : 33,
                         "name" : "ExpressionStatement",
-                        "src" : "346:30:0"
+                        "src" : "412:30:0"
                       }
                     ],
-                    "id" : 22,
+                    "id" : 34,
                     "name" : "Block",
-                    "src" : "276:105:0"
+                    "src" : "342:105:0"
                   }
                 ],
-                "id" : 23,
+                "id" : 35,
                 "name" : "FunctionDefinition",
-                "src" : "223:158:0"
+                "src" : "289:158:0"
               },
               {
                 "attributes" : 
@@ -418,9 +608,9 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 24,
+                    "id" : 36,
                     "name" : "ParameterList",
-                    "src" : "461:2:0"
+                    "src" : "527:2:0"
                   },
                   {
                     "children" : 
@@ -458,16 +648,16 @@
                                   ],
                                   "overloadedDeclarations" : 
                                   [
-                                    90,
-                                    91
+                                    99,
+                                    100
                                   ],
-                                  "referencedDeclaration" : 90,
+                                  "referencedDeclaration" : 99,
                                   "type" : "function (bool) pure",
                                   "value" : "require"
                                 },
-                                "id" : 25,
+                                "id" : 37,
                                 "name" : "Identifier",
-                                "src" : "470:7:0"
+                                "src" : "536:7:0"
                               },
                               {
                                 "attributes" : 
@@ -519,13 +709,13 @@
                                           [
                                             null
                                           ],
-                                          "referencedDeclaration" : 81,
+                                          "referencedDeclaration" : 90,
                                           "type" : "function (bytes memory) pure returns (bytes32)",
                                           "value" : "keccak256"
                                         },
-                                        "id" : 26,
+                                        "id" : 38,
                                         "name" : "Identifier",
-                                        "src" : "478:9:0"
+                                        "src" : "544:9:0"
                                       },
                                       {
                                         "attributes" : 
@@ -573,18 +763,18 @@
                                                   [
                                                     null
                                                   ],
-                                                  "referencedDeclaration" : 74,
+                                                  "referencedDeclaration" : 83,
                                                   "type" : "abi",
                                                   "value" : "abi"
                                                 },
-                                                "id" : 27,
+                                                "id" : 39,
                                                 "name" : "Identifier",
-                                                "src" : "488:3:0"
+                                                "src" : "554:3:0"
                                               }
                                             ],
-                                            "id" : 28,
+                                            "id" : 40,
                                             "name" : "MemberAccess",
-                                            "src" : "488:16:0"
+                                            "src" : "554:16:0"
                                           },
                                           {
                                             "attributes" : 
@@ -600,19 +790,19 @@
                                               "type" : "literal_string \"Nu Token\"",
                                               "value" : "Nu Token"
                                             },
-                                            "id" : 29,
+                                            "id" : 41,
                                             "name" : "Literal",
-                                            "src" : "505:10:0"
+                                            "src" : "571:10:0"
                                           }
                                         ],
-                                        "id" : 30,
+                                        "id" : 42,
                                         "name" : "FunctionCall",
-                                        "src" : "488:28:0"
+                                        "src" : "554:28:0"
                                       }
                                     ],
-                                    "id" : 31,
+                                    "id" : 43,
                                     "name" : "FunctionCall",
-                                    "src" : "478:39:0"
+                                    "src" : "544:39:0"
                                   },
                                   {
                                     "attributes" : 
@@ -648,7 +838,7 @@
                                           "isPure" : false,
                                           "lValueRequested" : false,
                                           "member_name" : "supportsToken",
-                                          "referencedDeclaration" : 71,
+                                          "referencedDeclaration" : 80,
                                           "type" : "function () external returns (bytes32)"
                                         },
                                         "children" : 
@@ -657,121 +847,57 @@
                                             "attributes" : 
                                             {
                                               "argumentTypes" : null,
-                                              "isConstant" : false,
-                                              "isLValue" : false,
-                                              "isPure" : false,
-                                              "isStructConstructorCall" : false,
-                                              "lValueRequested" : false,
-                                              "names" : 
+                                              "overloadedDeclarations" : 
                                               [
                                                 null
                                               ],
+                                              "referencedDeclaration" : 10,
                                               "type" : "contract Bank",
-                                              "type_conversion" : true
+                                              "value" : "bank"
                                             },
-                                            "children" : 
-                                            [
-                                              {
-                                                "attributes" : 
-                                                {
-                                                  "argumentTypes" : 
-                                                  [
-                                                    {
-                                                      "typeIdentifier" : "t_address_payable",
-                                                      "typeString" : "address payable"
-                                                    }
-                                                  ],
-                                                  "overloadedDeclarations" : 
-                                                  [
-                                                    null
-                                                  ],
-                                                  "referencedDeclaration" : 72,
-                                                  "type" : "type(contract Bank)",
-                                                  "value" : "Bank"
-                                                },
-                                                "id" : 32,
-                                                "name" : "Identifier",
-                                                "src" : "521:4:0"
-                                              },
-                                              {
-                                                "attributes" : 
-                                                {
-                                                  "argumentTypes" : null,
-                                                  "isConstant" : false,
-                                                  "isLValue" : false,
-                                                  "isPure" : false,
-                                                  "lValueRequested" : false,
-                                                  "member_name" : "sender",
-                                                  "referencedDeclaration" : null,
-                                                  "type" : "address payable"
-                                                },
-                                                "children" : 
-                                                [
-                                                  {
-                                                    "attributes" : 
-                                                    {
-                                                      "argumentTypes" : null,
-                                                      "overloadedDeclarations" : 
-                                                      [
-                                                        null
-                                                      ],
-                                                      "referencedDeclaration" : 87,
-                                                      "type" : "msg",
-                                                      "value" : "msg"
-                                                    },
-                                                    "id" : 33,
-                                                    "name" : "Identifier",
-                                                    "src" : "526:3:0"
-                                                  }
-                                                ],
-                                                "id" : 34,
-                                                "name" : "MemberAccess",
-                                                "src" : "526:10:0"
-                                              }
-                                            ],
-                                            "id" : 35,
-                                            "name" : "FunctionCall",
-                                            "src" : "521:16:0"
+                                            "id" : 44,
+                                            "name" : "Identifier",
+                                            "src" : "587:4:0"
                                           }
                                         ],
-                                        "id" : 36,
+                                        "id" : 45,
                                         "name" : "MemberAccess",
-                                        "src" : "521:30:0"
+                                        "src" : "587:18:0"
                                       }
                                     ],
-                                    "id" : 37,
+                                    "id" : 46,
                                     "name" : "FunctionCall",
-                                    "src" : "521:32:0"
+                                    "src" : "587:20:0"
                                   }
                                 ],
-                                "id" : 38,
+                                "id" : 47,
                                 "name" : "BinaryOperation",
-                                "src" : "478:75:0"
+                                "src" : "544:63:0"
                               }
                             ],
-                            "id" : 39,
+                            "id" : 48,
                             "name" : "FunctionCall",
-                            "src" : "470:84:0"
+                            "src" : "536:72:0"
                           }
                         ],
-                        "id" : 40,
+                        "id" : 49,
                         "name" : "ExpressionStatement",
-                        "src" : "470:84:0"
+                        "src" : "536:72:0"
                       },
                       {
-                        "id" : 41,
+                        "id" : 50,
                         "name" : "PlaceholderStatement",
-                        "src" : "560:1:0"
+                        "src" : "614:1:0"
                       }
                     ],
-                    "id" : 42,
+                    "id" : 51,
                     "name" : "Block",
-                    "src" : "464:102:0"
+                    "src" : "530:90:0"
                   }
                 ],
-                "id" : 43,
+                "id" : 52,
                 "name" : "ModifierDefinition",
-                "src" : "439:127:0"
+                "src" : "505:115:0"
               },
               {
                 "attributes" : 
@@ -791,9 +917,9 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 44,
+                    "id" : 53,
                     "name" : "ParameterList",
-                    "src" : "637:0:0"
+                    "src" : "691:0:0"
                   },
                   {
                     "children" : 
@@ -831,16 +957,16 @@
                                   ],
                                   "overloadedDeclarations" : 
                                   [
-                                    90,
-                                    91
+                                    99,
+                                    100
                                   ],
-                                  "referencedDeclaration" : 90,
+                                  "referencedDeclaration" : 99,
                                   "type" : "function (bool) pure",
                                   "value" : "require"
                                 },
-                                "id" : 45,
+                                "id" : 54,
                                 "name" : "Identifier",
-                                "src" : "645:7:0"
+                                "src" : "699:7:0"
                               },
                               {
                                 "attributes" : 
@@ -884,9 +1010,9 @@
                                           "type" : "mapping(address => uint256)",
                                           "value" : "tokenBalance"
                                         },
-                                        "id" : 46,
+                                        "id" : 55,
                                         "name" : "Identifier",
-                                        "src" : "653:12:0"
+                                        "src" : "707:12:0"
                                       },
                                       {
                                         "attributes" : 
@@ -910,23 +1036,23 @@
                                               [
                                                 null
                                               ],
-                                              "referencedDeclaration" : 87,
+                                              "referencedDeclaration" : 96,
                                               "type" : "msg",
                                               "value" : "msg"
                                             },
-                                            "id" : 47,
+                                            "id" : 56,
                                             "name" : "Identifier",
-                                            "src" : "666:3:0"
+                                            "src" : "720:3:0"
                                           }
                                         ],
-                                        "id" : 48,
+                                        "id" : 57,
                                         "name" : "MemberAccess",
-                                        "src" : "666:10:0"
+                                        "src" : "720:10:0"
                                       }
                                     ],
-                                    "id" : 49,
+                                    "id" : 58,
                                     "name" : "IndexAccess",
-                                    "src" : "653:24:0"
+                                    "src" : "707:24:0"
                                   },
                                   {
                                     "attributes" : 
@@ -942,44 +1068,44 @@
                                       "type" : "int_const 0",
                                       "value" : "0"
                                     },
-                                    "id" : 50,
+                                    "id" : 59,
                                     "name" : "Literal",
-                                    "src" : "681:1:0"
+                                    "src" : "735:1:0"
                                   }
                                 ],
-                                "id" : 51,
+                                "id" : 60,
                                 "name" : "BinaryOperation",
-                                "src" : "653:29:0"
+                                "src" : "707:29:0"
                               }
                             ],
-                            "id" : 52,
+                            "id" : 61,
                             "name" : "FunctionCall",
-                            "src" : "645:38:0"
+                            "src" : "699:38:0"
                           }
                         ],
-                        "id" : 53,
+                        "id" : 62,
                         "name" : "ExpressionStatement",
-                        "src" : "645:38:0"
+                        "src" : "699:38:0"
                       },
                       {
-                        "id" : 54,
+                        "id" : 63,
                         "name" : "PlaceholderStatement",
-                        "src" : "691:1:0"
+                        "src" : "745:1:0"
                       }
                     ],
-                    "id" : 55,
+                    "id" : 64,
                     "name" : "Block",
-                    "src" : "637:60:0"
+                    "src" : "691:60:0"
                   }
                 ],
-                "id" : 56,
+                "id" : 65,
                 "name" : "ModifierDefinition",
-                "src" : "615:82:0"
+                "src" : "669:82:0"
               }
             ],
-            "id" : 57,
+            "id" : 66,
             "name" : "ContractDefinition",
-            "src" : "25:674:0"
+            "src" : "25:728:0"
           },
           {
             "attributes" : 
@@ -997,10 +1123,10 @@
               "fullyImplemented" : true,
               "linearizedBaseContracts" : 
               [
-                72
+                81
               ],
               "name" : "Bank",
-              "scope" : 73
+              "scope" : 82
             },
             "children" : 
             [
@@ -1016,7 +1142,7 @@
                     null
                   ],
                   "name" : "supportsToken",
-                  "scope" : 72,
+                  "scope" : 81,
                   "stateMutability" : "nonpayable",
                   "superFunction" : null,
                   "visibility" : "external"
@@ -1032,9 +1158,9 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 58,
+                    "id" : 67,
                     "name" : "ParameterList",
-                    "src" : "743:2:0"
+                    "src" : "797:2:0"
                   },
                   {
                     "children" : 
@@ -1044,7 +1170,7 @@
                         {
                           "constant" : false,
                           "name" : "",
-                          "scope" : 71,
+                          "scope" : 80,
                           "stateVariable" : false,
                           "storageLocation" : "default",
                           "type" : "bytes32",
@@ -1059,19 +1185,19 @@
                               "name" : "bytes32",
                               "type" : "bytes32"
                             },
-                            "id" : 59,
+                            "id" : 68,
                             "name" : "ElementaryTypeName",
-                            "src" : "763:7:0"
+                            "src" : "817:7:0"
                           }
                         ],
-                        "id" : 60,
+                        "id" : 69,
                         "name" : "VariableDeclaration",
-                        "src" : "763:7:0"
+                        "src" : "817:7:0"
                       }
                     ],
-                    "id" : 61,
+                    "id" : 70,
                     "name" : "ParameterList",
-                    "src" : "762:9:0"
+                    "src" : "816:9:0"
                   },
                   {
                     "children" : 
@@ -1079,7 +1205,7 @@
                       {
                         "attributes" : 
                         {
-                          "functionReturnParameters" : 61
+                          "functionReturnParameters" : 70
                         },
                         "children" : 
                         [
@@ -1128,13 +1254,13 @@
                                       [
                                         null
                                       ],
-                                      "referencedDeclaration" : 81,
+                                      "referencedDeclaration" : 90,
                                       "type" : "function (bytes memory) pure returns (bytes32)",
                                       "value" : "keccak256"
                                     },
-                                    "id" : 62,
+                                    "id" : 71,
                                     "name" : "Identifier",
-                                    "src" : "788:9:0"
+                                    "src" : "842:9:0"
                                   },
                                   {
                                     "attributes" : 
@@ -1182,18 +1308,18 @@
                                               [
                                                 null
                                               ],
-                                              "referencedDeclaration" : 74,
+                                              "referencedDeclaration" : 83,
                                               "type" : "abi",
                                               "value" : "abi"
                                             },
-                                            "id" : 63,
+                                            "id" : 72,
                                             "name" : "Identifier",
-                                            "src" : "798:3:0"
+                                            "src" : "852:3:0"
                                           }
                                         ],
-                                        "id" : 64,
+                                        "id" : 73,
                                         "name" : "MemberAccess",
-                                        "src" : "798:16:0"
+                                        "src" : "852:16:0"
                                       },
                                       {
                                         "attributes" : 
@@ -1209,49 +1335,49 @@
                                           "type" : "literal_string \"Nu Token\"",
                                           "value" : "Nu Token"
                                         },
-                                        "id" : 65,
+                                        "id" : 74,
                                         "name" : "Literal",
-                                        "src" : "815:10:0"
+                                        "src" : "869:10:0"
                                       }
                                     ],
-                                    "id" : 66,
+                                    "id" : 75,
                                     "name" : "FunctionCall",
-                                    "src" : "798:28:0"
+                                    "src" : "852:28:0"
                                   }
                                 ],
-                                "id" : 67,
+                                "id" : 76,
                                 "name" : "FunctionCall",
-                                "src" : "788:39:0"
+                                "src" : "842:39:0"
                               }
                             ],
-                            "id" : 68,
+                            "id" : 77,
                             "name" : "TupleExpression",
-                            "src" : "787:41:0"
+                            "src" : "841:41:0"
                           }
                         ],
-                        "id" : 69,
+                        "id" : 78,
                         "name" : "Return",
-                        "src" : "781:47:0"
+                        "src" : "835:47:0"
                       }
                     ],
-                    "id" : 70,
+                    "id" : 79,
                     "name" : "Block",
-                    "src" : "771:64:0"
+                    "src" : "825:64:0"
                   }
                 ],
-                "id" : 71,
+                "id" : 80,
                 "name" : "FunctionDefinition",
-                "src" : "721:114:0"
+                "src" : "775:114:0"
               }
             ],
-            "id" : 72,
+            "id" : 81,
             "name" : "ContractDefinition",
-            "src" : "701:136:0"
+            "src" : "755:136:0"
           }
         ],
-        "id" : 73,
+        "id" : 82,
         "name" : "SourceUnit",
-        "src" : "0:838:0"
+        "src" : "0:892:0"
       }
     }
   },

--- a/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.json
+++ b/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.json
@@ -3,15 +3,15 @@
   {
     "modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol:Bank" : 
     {
-      "bin" : "6080604052348015600f57600080fd5b5060cb8061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000600160008190555060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820842f30d24bfb641a95748ca265af0de36b02b8239b5089b8adce1e4a250919ed0029",
-      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000600160008190555060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820842f30d24bfb641a95748ca265af0de36b02b8239b5089b8adce1e4a250919ed0029",
-      "srcmap" : "701:178:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:178:0;;;;;;;",
-      "srcmap-runtime" : "701:178:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:178:0;;;;;;;;;;;;;;;;;;;740:137;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;782:7;812:1;800:9;:13;;;;840:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;840:28:0;;;830:39;;;;;;823:47;;740:137;:::o"
+      "bin" : "6080604052348015600f57600080fd5b5060c38061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820a17c196af6cd011669c8624a23d7c075e95b4538bfac3edb06ccaf04936b59ed0029",
+      "bin-runtime" : "6080604052348015600f57600080fd5b506004361060285760003560e01c80634d5f327c14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b600060405160200180807f4e7520546f6b656e00000000000000000000000000000000000000000000000081525060080190506040516020818303038152906040528051906020012090509056fea165627a7a72305820a17c196af6cd011669c8624a23d7c075e95b4538bfac3edb06ccaf04936b59ed0029",
+      "srcmap" : "701:136:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:136:0;;;;;;;",
+      "srcmap-runtime" : "701:136:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;701:136:0;;;;;;;;;;;;;;;;;;;721:114;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;763:7;798:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;798:28:0;;;788:39;;;;;;781:47;;721:114;:::o"
     },
     "modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol:ModifierEntrancy" : 
     {
-      "bin" : "608060405234801561001057600080fd5b5061024f806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b1580156100e557600080fd5b505af11580156100f9573d6000803e3d6000fd5b505050506040513d602081101561010f57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461017157600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208c1e8b52bb3fabb6919876400a3ba0d07bb91716a625cfc549ce727ebff53aea0029",
-      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b1580156100e557600080fd5b505af11580156100f9573d6000803e3d6000fd5b505050506040513d602081101561010f57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461017157600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058208c1e8b52bb3fabb6919876400a3ba0d07bb91716a625cfc549ce727ebff53aea0029",
+      "bin" : "608060405234801561001057600080fd5b5061024f806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b1580156100e557600080fd5b505af11580156100f9573d6000803e3d6000fd5b505050506040513d602081101561010f57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461017157600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058209f76f51b29f6f5aeb4d21da2190521394d23b63c9c21b863f126f27f9aadb6580029",
+      "bin-runtime" : "608060405234801561001057600080fd5b50600436106100365760003560e01c8063ca5d08801461003b578063eedc966a14610045575b600080fd5b61004361009d565b005b6100876004803603602081101561005b57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061020b565b6040518082815260200191505060405180910390f35b3373ffffffffffffffffffffffffffffffffffffffff16634d5f327c6040518163ffffffff1660e01b8152600401602060405180830381600087803b1580156100e557600080fd5b505af11580156100f9573d6000803e3d6000fd5b505050506040513d602081101561010f57600080fd5b810190808051906020019092919050505060405160200180807f4e7520546f6b656e0000000000000000000000000000000000000000000000008152506008019050604051602081830303815290604052805190602001201461017157600080fd5b60008060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054146101bc57600080fd5b60146000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550565b6000602052806000526040600020600091509050548156fea165627a7a723058209f76f51b29f6f5aeb4d21da2190521394d23b63c9c21b863f126f27f9aadb6580029",
       "srcmap" : "25:674:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:674:0;;;;;;;",
       "srcmap-runtime" : "25:674:0:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;25:674:0;;;;;;;;;;;;;;;;;;;;;;;;223:158;;;:::i;:::-;;55:45;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;55:45:0;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;223:158;526:10;521:30;;;:32;;;;;;;;;;;;;;;;;;;;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;521:32:0;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;521:32:0;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;521:32:0;;;;;;;;;;;;;;;;488:28;;;;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;488:28:0;;;478:39;;;;;;:75;470:84;;;;;;681:1;653:12;:24;666:10;653:24;;;;;;;;;;;;;;;;:29;645:38;;;;;;374:2;346:12;:24;359:10;346:24;;;;;;;;;;;;;;;;:30;;;;;;;;;;;223:158::o;55:45::-;;;;;;;;;;;;;;;;;:::o"
     }
@@ -33,7 +33,7 @@
           {
             "Bank" : 
             [
-              78
+              72
             ],
             "ModifierEntrancy" : 
             [
@@ -77,7 +77,7 @@
                 57
               ],
               "name" : "ModifierEntrancy",
-              "scope" : 79
+              "scope" : 73
             },
             "children" : 
             [
@@ -344,7 +344,7 @@
                                           [
                                             null
                                           ],
-                                          "referencedDeclaration" : 93,
+                                          "referencedDeclaration" : 87,
                                           "type" : "msg",
                                           "value" : "msg"
                                         },
@@ -458,10 +458,10 @@
                                   ],
                                   "overloadedDeclarations" : 
                                   [
-                                    96,
-                                    97
+                                    90,
+                                    91
                                   ],
-                                  "referencedDeclaration" : 96,
+                                  "referencedDeclaration" : 90,
                                   "type" : "function (bool) pure",
                                   "value" : "require"
                                 },
@@ -519,7 +519,7 @@
                                           [
                                             null
                                           ],
-                                          "referencedDeclaration" : 87,
+                                          "referencedDeclaration" : 81,
                                           "type" : "function (bytes memory) pure returns (bytes32)",
                                           "value" : "keccak256"
                                         },
@@ -573,7 +573,7 @@
                                                   [
                                                     null
                                                   ],
-                                                  "referencedDeclaration" : 80,
+                                                  "referencedDeclaration" : 74,
                                                   "type" : "abi",
                                                   "value" : "abi"
                                                 },
@@ -648,7 +648,7 @@
                                           "isPure" : false,
                                           "lValueRequested" : false,
                                           "member_name" : "supportsToken",
-                                          "referencedDeclaration" : 77,
+                                          "referencedDeclaration" : 71,
                                           "type" : "function () external returns (bytes32)"
                                         },
                                         "children" : 
@@ -685,7 +685,7 @@
                                                   [
                                                     null
                                                   ],
-                                                  "referencedDeclaration" : 78,
+                                                  "referencedDeclaration" : 72,
                                                   "type" : "type(contract Bank)",
                                                   "value" : "Bank"
                                                 },
@@ -715,7 +715,7 @@
                                                       [
                                                         null
                                                       ],
-                                                      "referencedDeclaration" : 93,
+                                                      "referencedDeclaration" : 87,
                                                       "type" : "msg",
                                                       "value" : "msg"
                                                     },
@@ -831,10 +831,10 @@
                                   ],
                                   "overloadedDeclarations" : 
                                   [
-                                    96,
-                                    97
+                                    90,
+                                    91
                                   ],
-                                  "referencedDeclaration" : 96,
+                                  "referencedDeclaration" : 90,
                                   "type" : "function (bool) pure",
                                   "value" : "require"
                                 },
@@ -910,7 +910,7 @@
                                               [
                                                 null
                                               ],
-                                              "referencedDeclaration" : 93,
+                                              "referencedDeclaration" : 87,
                                               "type" : "msg",
                                               "value" : "msg"
                                             },
@@ -997,42 +997,13 @@
               "fullyImplemented" : true,
               "linearizedBaseContracts" : 
               [
-                78
+                72
               ],
               "name" : "Bank",
-              "scope" : 79
+              "scope" : 73
             },
             "children" : 
             [
-              {
-                "attributes" : 
-                {
-                  "constant" : false,
-                  "name" : "state_var",
-                  "scope" : 78,
-                  "stateVariable" : true,
-                  "storageLocation" : "default",
-                  "type" : "uint256",
-                  "value" : null,
-                  "visibility" : "internal"
-                },
-                "children" : 
-                [
-                  {
-                    "attributes" : 
-                    {
-                      "name" : "uint",
-                      "type" : "uint256"
-                    },
-                    "id" : 58,
-                    "name" : "ElementaryTypeName",
-                    "src" : "720:4:0"
-                  }
-                ],
-                "id" : 59,
-                "name" : "VariableDeclaration",
-                "src" : "720:14:0"
-              },
               {
                 "attributes" : 
                 {
@@ -1045,7 +1016,7 @@
                     null
                   ],
                   "name" : "supportsToken",
-                  "scope" : 78,
+                  "scope" : 72,
                   "stateMutability" : "nonpayable",
                   "superFunction" : null,
                   "visibility" : "external"
@@ -1061,9 +1032,9 @@
                       ]
                     },
                     "children" : [],
-                    "id" : 60,
+                    "id" : 58,
                     "name" : "ParameterList",
-                    "src" : "762:2:0"
+                    "src" : "743:2:0"
                   },
                   {
                     "children" : 
@@ -1073,7 +1044,7 @@
                         {
                           "constant" : false,
                           "name" : "",
-                          "scope" : 77,
+                          "scope" : 71,
                           "stateVariable" : false,
                           "storageLocation" : "default",
                           "type" : "bytes32",
@@ -1088,87 +1059,27 @@
                               "name" : "bytes32",
                               "type" : "bytes32"
                             },
-                            "id" : 61,
+                            "id" : 59,
                             "name" : "ElementaryTypeName",
-                            "src" : "782:7:0"
+                            "src" : "763:7:0"
                           }
                         ],
-                        "id" : 62,
+                        "id" : 60,
                         "name" : "VariableDeclaration",
-                        "src" : "782:7:0"
+                        "src" : "763:7:0"
                       }
                     ],
-                    "id" : 63,
+                    "id" : 61,
                     "name" : "ParameterList",
-                    "src" : "781:9:0"
+                    "src" : "762:9:0"
                   },
                   {
                     "children" : 
                     [
                       {
-                        "children" : 
-                        [
-                          {
-                            "attributes" : 
-                            {
-                              "argumentTypes" : null,
-                              "isConstant" : false,
-                              "isLValue" : false,
-                              "isPure" : false,
-                              "lValueRequested" : false,
-                              "operator" : "=",
-                              "type" : "uint256"
-                            },
-                            "children" : 
-                            [
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "overloadedDeclarations" : 
-                                  [
-                                    null
-                                  ],
-                                  "referencedDeclaration" : 59,
-                                  "type" : "uint256",
-                                  "value" : "state_var"
-                                },
-                                "id" : 64,
-                                "name" : "Identifier",
-                                "src" : "800:9:0"
-                              },
-                              {
-                                "attributes" : 
-                                {
-                                  "argumentTypes" : null,
-                                  "hexvalue" : "31",
-                                  "isConstant" : false,
-                                  "isLValue" : false,
-                                  "isPure" : true,
-                                  "lValueRequested" : false,
-                                  "subdenomination" : null,
-                                  "token" : "number",
-                                  "type" : "int_const 1",
-                                  "value" : "1"
-                                },
-                                "id" : 65,
-                                "name" : "Literal",
-                                "src" : "812:1:0"
-                              }
-                            ],
-                            "id" : 66,
-                            "name" : "Assignment",
-                            "src" : "800:13:0"
-                          }
-                        ],
-                        "id" : 67,
-                        "name" : "ExpressionStatement",
-                        "src" : "800:13:0"
-                      },
-                      {
                         "attributes" : 
                         {
-                          "functionReturnParameters" : 63
+                          "functionReturnParameters" : 61
                         },
                         "children" : 
                         [
@@ -1217,13 +1128,13 @@
                                       [
                                         null
                                       ],
-                                      "referencedDeclaration" : 87,
+                                      "referencedDeclaration" : 81,
                                       "type" : "function (bytes memory) pure returns (bytes32)",
                                       "value" : "keccak256"
                                     },
-                                    "id" : 68,
+                                    "id" : 62,
                                     "name" : "Identifier",
-                                    "src" : "830:9:0"
+                                    "src" : "788:9:0"
                                   },
                                   {
                                     "attributes" : 
@@ -1271,18 +1182,18 @@
                                               [
                                                 null
                                               ],
-                                              "referencedDeclaration" : 80,
+                                              "referencedDeclaration" : 74,
                                               "type" : "abi",
                                               "value" : "abi"
                                             },
-                                            "id" : 69,
+                                            "id" : 63,
                                             "name" : "Identifier",
-                                            "src" : "840:3:0"
+                                            "src" : "798:3:0"
                                           }
                                         ],
-                                        "id" : 70,
+                                        "id" : 64,
                                         "name" : "MemberAccess",
-                                        "src" : "840:16:0"
+                                        "src" : "798:16:0"
                                       },
                                       {
                                         "attributes" : 
@@ -1298,49 +1209,49 @@
                                           "type" : "literal_string \"Nu Token\"",
                                           "value" : "Nu Token"
                                         },
-                                        "id" : 71,
+                                        "id" : 65,
                                         "name" : "Literal",
-                                        "src" : "857:10:0"
+                                        "src" : "815:10:0"
                                       }
                                     ],
-                                    "id" : 72,
+                                    "id" : 66,
                                     "name" : "FunctionCall",
-                                    "src" : "840:28:0"
+                                    "src" : "798:28:0"
                                   }
                                 ],
-                                "id" : 73,
+                                "id" : 67,
                                 "name" : "FunctionCall",
-                                "src" : "830:39:0"
+                                "src" : "788:39:0"
                               }
                             ],
-                            "id" : 74,
+                            "id" : 68,
                             "name" : "TupleExpression",
-                            "src" : "829:41:0"
+                            "src" : "787:41:0"
                           }
                         ],
-                        "id" : 75,
+                        "id" : 69,
                         "name" : "Return",
-                        "src" : "823:47:0"
+                        "src" : "781:47:0"
                       }
                     ],
-                    "id" : 76,
+                    "id" : 70,
                     "name" : "Block",
-                    "src" : "790:87:0"
+                    "src" : "771:64:0"
                   }
                 ],
-                "id" : 77,
+                "id" : 71,
                 "name" : "FunctionDefinition",
-                "src" : "740:137:0"
+                "src" : "721:114:0"
               }
             ],
-            "id" : 78,
+            "id" : 72,
             "name" : "ContractDefinition",
-            "src" : "701:178:0"
+            "src" : "701:136:0"
           }
         ],
-        "id" : 79,
+        "id" : 73,
         "name" : "SourceUnit",
-        "src" : "0:880:0"
+        "src" : "0:838:0"
       }
     }
   },

--- a/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol
+++ b/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol
@@ -22,9 +22,8 @@ contract ModifierEntrancy {
 }
 
 contract Bank{
-    uint state_var;
+
     function supportsToken() external returns(bytes32){
-        state_var = 1;
         return(keccak256(abi.encodePacked("Nu Token")));
     }
 }

--- a/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol
+++ b/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.5.0;
 contract ModifierEntrancy {
   mapping (address => uint) public tokenBalance;
   string constant name = "Nu Token";
+  Bank bank;
+  constructor() public{
+      bank = new Bank();
+  }
 
   //If a contract has a zero balance and supports the token give them some token
   function airDrop() supportsToken hasNoBalance  public{ // In the fixed version supportsToken comes before hasNoBalance
@@ -11,7 +15,7 @@ contract ModifierEntrancy {
 
   //Checks that the contract responds the way we want
   modifier supportsToken() {
-    require(keccak256(abi.encodePacked("Nu Token")) == Bank(msg.sender).supportsToken());
+    require(keccak256(abi.encodePacked("Nu Token")) == bank.supportsToken());
     _;
   }
   //Checks that the caller has a zero balance

--- a/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol
+++ b/test_cases/solidity/reentracy/modifier_reentrancy_fixed/modifier_reentrancy_fixed.sol
@@ -22,7 +22,9 @@ contract ModifierEntrancy {
 }
 
 contract Bank{
-    function supportsToken() external pure returns(bytes32){
+    uint state_var;
+    function supportsToken() external returns(bytes32){
+        state_var = 1;
         return(keccak256(abi.encodePacked("Nu Token")));
     }
 }


### PR DESCRIPTION
This example has a static call which doesn't cause reentrancy as  state can't get changed, So it was a safe case.