### PR TITLE
Change the line number for SWC-132 Lockdrop.sol

### DIFF
--- a/test_cases/solidity/real_world_samples/Lockdrop/Lockdrop.yaml
+++ b/test_cases/solidity/real_world_samples/Lockdrop/Lockdrop.yaml
@@ -5,4 +5,4 @@ issues:
   locations:
   - bytecode_offsets: {}
     line_numbers:
-      Lockdrop.sol: [65]
+      Lockdrop.sol: [69]


### PR DESCRIPTION
Change the line number for the vulnerability to assert statement, as that's where the strict equality check for ether balance is.