### PR TITLE
Don't recommend .transfer()

### DIFF
--- a/entries/SWC-107.md
+++ b/entries/SWC-107.md
@@ -12,8 +12,8 @@ One of the major dangers of calling external contracts is that they can take ove
 
 The best practices to avoid Reentrancy weaknesses are: 
 
-- Use `transfer()` instead of `contract.call()` to transfer Ether to untrusted addresses. 
-- When using low-level calls, make sure all internal state changes are performed before the call is executed.
+- Make sure all internal state changes are performed before the call is executed. This is known as the [Checks-Effects-Interactions pattern](https://solidity.readthedocs.io/en/latest/security-considerations.html#use-the-checks-effects-interactions-pattern)
+- Use a reentrancy lock (ie.  [OpenZeppelin's ReentrancyGuard](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/ReentrancyGuard.sol).
 
 ## References 
 


### PR DESCRIPTION
Consistent with https://diligence.consensys.net/blog/2019/09/stop-using-soliditys-transfer-now/

I checked the test cases, they were fine: https://swcregistry.io/docs/SWC-107#contract-samples